### PR TITLE
Fix MySQL schema scoping for table discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ The config file allows you to ignore specific tables:
 
 ```php
 return [
+    'schema' => null,
+
     'ignore_tables' => [
         'migrations',
         'failed_jobs',
@@ -88,6 +90,10 @@ return [
     ],
 ];
 ```
+
+By default, MySQL connections are scoped to the active database name so tables
+from other visible databases are not included in the diagram. Set `schema` if you
+want to inspect a specific schema/database explicitly.
 
 ### Smart relationship detection
 

--- a/config/mermaid-erd.php
+++ b/config/mermaid-erd.php
@@ -13,6 +13,8 @@ return [
         'cache_locks',
     ],
 
+    'schema' => null,
+
     'guess_relationships' => true,
 
     'polymorphic_relationships' => [

--- a/src/Commands/LaravelMermaidErdCommand.php
+++ b/src/Commands/LaravelMermaidErdCommand.php
@@ -34,6 +34,7 @@ class LaravelMermaidErdCommand extends Command
             $connection,
             config('mermaid-erd.ignore_tables', []),
             $onlyTables,
+            config('mermaid-erd.schema'),
         );
 
         $generator = new MermaidErdGenerator(

--- a/src/DatabaseInformationService.php
+++ b/src/DatabaseInformationService.php
@@ -10,11 +10,12 @@ class DatabaseInformationService
         private readonly Connection $db,
         private readonly array $ignoreTables = [],
         private readonly array $onlyTables = [],
+        private readonly ?string $schema = null,
     ) {}
 
     public function getTables(): array
     {
-        $tables = $this->db->getSchemaBuilder()->getTables();
+        $tables = $this->db->getSchemaBuilder()->getTables($this->getSchemaName());
         $tableNames = array_map(fn (array $table) => $table['name'], $tables);
 
         if ($this->onlyTables !== []) {
@@ -37,5 +38,18 @@ class DatabaseInformationService
     public function getIndexes(string $table): array
     {
         return $this->db->getSchemaBuilder()->getIndexes($table);
+    }
+
+    private function getSchemaName(): ?string
+    {
+        if ($this->schema !== null) {
+            return $this->schema;
+        }
+
+        if ($this->db->getDriverName() === 'mysql') {
+            return $this->db->getDatabaseName();
+        }
+
+        return null;
     }
 }

--- a/src/Http/MermaidErdController.php
+++ b/src/Http/MermaidErdController.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 namespace Bambamboole\LaravelMermaidErd\Http;
 
 use Bambamboole\LaravelMermaidErd\MermaidErdGenerator;
-use Illuminate\Contracts\View\View;
+use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\View;
 
 class MermaidErdController
 {
-    public function __invoke(MermaidErdGenerator $generator): View
+    public function __invoke(MermaidErdGenerator $generator): ViewContract
     {
         $connectionName = config('database.default');
         $cacheKey = "mermaid-erd:diagram:{$connectionName}";
@@ -24,7 +25,7 @@ class MermaidErdController
             $diagram = $generator->generate();
         }
 
-        return view('mermaid-erd::diagram', [
+        return View::make('mermaid-erd::diagram', [
             'connectionName' => $connectionName,
             'diagram' => htmlspecialchars($diagram, ENT_QUOTES, 'UTF-8'),
             'mermaidConfig' => json_encode(config('mermaid-erd.web.mermaid', []), JSON_THROW_ON_ERROR),

--- a/tests/DatabaseInformationServiceTest.php
+++ b/tests/DatabaseInformationServiceTest.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 
 use Bambamboole\LaravelMermaidErd\DatabaseInformationService;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Schema\Builder;
 
 it('retrieves tables from a real database', function () {
     $service = new DatabaseInformationService($this->app['db']->connection());
@@ -73,4 +75,65 @@ it('filters to only specified tables', function () {
         ->not->toContain('comments')
         ->not->toContain('tags')
         ->not->toContain('post_tag');
+});
+
+it('scopes mysql table discovery to the current database by default', function () {
+    $schemaBuilder = Mockery::mock(Builder::class);
+    $schemaBuilder
+        ->shouldReceive('getTables')
+        ->once()
+        ->with('app_database')
+        ->andReturn([
+            ['name' => 'users'],
+            ['name' => 'posts'],
+        ]);
+
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('getSchemaBuilder')->once()->andReturn($schemaBuilder);
+    $connection->shouldReceive('getDriverName')->once()->andReturn('mysql');
+    $connection->shouldReceive('getDatabaseName')->once()->andReturn('app_database');
+
+    $service = new DatabaseInformationService($connection);
+
+    expect($service->getTables())->toBe(['users', 'posts']);
+});
+
+it('uses configured schema for table discovery when provided', function () {
+    $schemaBuilder = Mockery::mock(Builder::class);
+    $schemaBuilder
+        ->shouldReceive('getTables')
+        ->once()
+        ->with('reporting_schema')
+        ->andReturn([
+            ['name' => 'invoices'],
+        ]);
+
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('getSchemaBuilder')->once()->andReturn($schemaBuilder);
+    $connection->shouldNotReceive('getDriverName');
+    $connection->shouldNotReceive('getDatabaseName');
+
+    $service = new DatabaseInformationService($connection, [], [], 'reporting_schema');
+
+    expect($service->getTables())->toBe(['invoices']);
+});
+
+it('keeps default schema discovery for non-mysql connections', function () {
+    $schemaBuilder = Mockery::mock(Builder::class);
+    $schemaBuilder
+        ->shouldReceive('getTables')
+        ->once()
+        ->with(null)
+        ->andReturn([
+            ['name' => 'comments'],
+        ]);
+
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('getSchemaBuilder')->once()->andReturn($schemaBuilder);
+    $connection->shouldReceive('getDriverName')->once()->andReturn('sqlite');
+    $connection->shouldNotReceive('getDatabaseName');
+
+    $service = new DatabaseInformationService($connection);
+
+    expect($service->getTables())->toBe(['comments']);
 });


### PR DESCRIPTION
## Summary
- scope MySQL table discovery to the active database name by default
- add optional `mermaid-erd.schema` config for explicit schema/database selection
- cover default MySQL scoping, configured schema overrides, and non-MySQL behavior with tests
- use `View::make()` in the web controller so PHPStan accepts the view return type

## Why
Laravel 12's MySQL schema builder may return tables from all visible non-system schemas when `getTables()` is called without a schema. If the database user can see multiple databases, generated ERDs can include unrelated tables and duplicate relationships.

## Verification
- `composer test`
- `composer format`
- `php -d memory_limit=512M vendor/bin/phpstan analyse`