### PR TITLE
Live table/column filter in the web view

### DIFF
--- a/.ai/guidelines/development.md
+++ b/.ai/guidelines/development.md
@@ -11,9 +11,10 @@
 - **Assertions on generated diagrams must stay driver-agnostic.** Column type names differ per
   driver (`integer` vs `bigint` vs `int8`) and defaults render differently (Postgres emits
   `nextval(...)`). Match constraint markers (`\w+ id PK`), never concrete type names.
-- The example ERD in `README.md` is generated from the workbench schema. Regenerate it whenever the
-  workbench migrations or the diagram output format change:
-  `vendor/bin/testbench workbench:build && vendor/bin/testbench generate:mermaid-erd --output=file --path=$PWD/README.md`
+- The example ERD in `README.md` is generated from the workbench schema, scoped to the original blog
+  tables so it stays readable (the full workbench schema is intentionally large to exercise the web
+  view filter). Regenerate it whenever those tables or the diagram output format change:
+  `vendor/bin/testbench workbench:build && vendor/bin/testbench generate:mermaid-erd --output=file --path=$PWD/README.md --tables=users,posts,comments,tags,post_tag,videos,reviews,categories,ai_messages`
 - Regenerate `CLAUDE.md` after editing `.ai/guidelines/`, `.ai/skills/`, or `boost.json` with
   `composer boost:refresh`.
 - The Boost path overrides for the Testbench context live in `workbench/app/Support/` and are wired

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ The generator automatically detects pivot tables (tables with exactly 2 foreign 
 
 The package also ships a web view that renders the diagram in the browser using Mermaid.js. It is enabled by default at `/mermaid-erd` and configurable via the `web` section of the config file.
 
-The view has a search box that filters the diagram live: type a table or column name and only matching tables plus their directly connected neighbors stay visible. The query is kept in the URL (`?q=orders`), so filtered views are shareable, and "Copy Mermaid" / "Download SVG" export exactly what is on screen.
+The view has a search box that filters the diagram live: type a table or column name and only matching tables plus their directly connected neighbors stay visible. Pivot tables are treated as pass-throughs — a many-to-many counts as one relation, so both of its sides stay visible. The query is kept in the URL (`?q=orders`), so filtered views are shareable, and "Copy Mermaid" / "Download SVG" export exactly what is on screen.
 
 ```php
 'web' => [

--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ The generator automatically detects pivot tables (tables with exactly 2 foreign 
 
 ## Web view
 
-The package also ships a web view that renders the diagram in the browser using Mermaid.js. It is enabled by default at `/mermaid-erd` and configurable via the `web` section of the config file:
+The package also ships a web view that renders the diagram in the browser using Mermaid.js. It is enabled by default at `/mermaid-erd` and configurable via the `web` section of the config file.
+
+The view has a search box that filters the diagram live: type a table or column name and only matching tables plus their directly connected neighbors stay visible. The query is kept in the URL (`?q=orders`), so filtered views are shareable, and "Copy Mermaid" / "Download SVG" export exactly what is on screen.
 
 ```php
 'web' => [

--- a/resources/views/diagram.blade.php
+++ b/resources/views/diagram.blade.php
@@ -77,7 +77,12 @@
 
         container.addEventListener('wheel', function(e) {
             e.preventDefault();
-            if (e.deltaY < 0) zoomIn(); else zoomOut();
+            // Zoom proportionally to the wheel delta: trackpads emit many
+            // small deltas (smooth glide), a mouse wheel notch (~100) matches
+            // roughly the old 15% step. deltaMode 1 means line-based deltas.
+            const delta = e.deltaMode === 1 ? e.deltaY * 24 : e.deltaY;
+            scale = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, scale * Math.exp(-delta * 0.002)));
+            applyTransform();
         }, { passive: false });
 
         container.addEventListener('mousedown', function(e) {

--- a/resources/views/diagram.blade.php
+++ b/resources/views/diagram.blade.php
@@ -152,6 +152,7 @@
         })(mermaidSource);
 
         const totalTables = Object.keys(graph.tables).length;
+        const pivots = new Set(graph.pivots);
 
         function computeVisible(query) {
             const q = query.trim().toLowerCase();
@@ -168,6 +169,13 @@
             for (const [from, to] of graph.edges) {
                 if (matched.has(from)) visible.add(to);
                 if (matched.has(to)) visible.add(from);
+            }
+
+            // Pivot tables are pass-throughs: a many-to-many is one logical
+            // relation, so both sides of a visible pivot stay visible.
+            for (const [from, to] of graph.edges) {
+                if (visible.has(from) && pivots.has(from)) visible.add(to);
+                if (visible.has(to) && pivots.has(to)) visible.add(from);
             }
 
             return visible;

--- a/resources/views/diagram.blade.php
+++ b/resources/views/diagram.blade.php
@@ -8,9 +8,14 @@
 </head>
 <body class="bg-gray-50 font-sans antialiased">
 
-    <header class="flex items-center justify-between border-b border-gray-200 bg-white px-6 py-3">
-        <h1 class="text-sm font-semibold text-gray-800">ERD &mdash; {{ $connectionName }}</h1>
-        <div class="flex items-center gap-2">
+    <header class="flex items-center justify-between gap-4 border-b border-gray-200 bg-white px-6 py-3">
+        <h1 class="shrink-0 text-sm font-semibold text-gray-800">ERD &mdash; {{ $connectionName }}</h1>
+        <div class="flex min-w-0 flex-1 items-center gap-2">
+            <input id="erd-search" type="search" placeholder="Filter tables &amp; columns&hellip;" autocomplete="off"
+                class="w-full max-w-72 rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs text-gray-700 outline-none transition focus:border-gray-400" />
+            <span id="erd-count" class="shrink-0 text-xs text-gray-500"></span>
+        </div>
+        <div class="flex shrink-0 items-center gap-2">
             <button onclick="zoomOut()" title="Zoom out"
                 class="rounded-md border border-gray-200 bg-white px-3 py-1.5 text-xs text-gray-600 transition hover:border-gray-300 hover:bg-gray-50 cursor-pointer">
                 &minus;
@@ -37,17 +42,16 @@
     </header>
 
     <div id="diagram-container" class="fixed inset-x-0 bottom-0 top-[49px] cursor-grab overflow-hidden">
-        <div id="diagram-wrapper" class="inline-block min-h-full min-w-full origin-top-left p-8">
-            <pre class="mermaid bg-transparent">{!! $diagram !!}</pre>
-        </div>
+        <div id="diagram-wrapper" class="inline-block min-h-full min-w-full origin-top-left p-8"></div>
     </div>
 
     <script>
-        const mermaidSource = {!! json_encode($diagram) !!};
+        const mermaidSource = {!! $diagram !!};
+        const graph = {!! $graph !!};
     </script>
     <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
     <script>
-        mermaid.initialize({!! $mermaidConfig !!});
+        mermaid.initialize(Object.assign({}, {!! $mermaidConfig !!}, { startOnLoad: false }));
 
         let scale = 1;
         let translateX = 0;
@@ -98,7 +102,7 @@
         });
 
         function copyMermaid() {
-            navigator.clipboard.writeText(mermaidSource).then(function() {
+            navigator.clipboard.writeText(currentSource).then(function() {
                 var btn = document.getElementById('copy-btn');
                 var original = btn.textContent;
                 btn.textContent = 'Copied!';
@@ -121,10 +125,123 @@
             document.body.removeChild(a);
             URL.revokeObjectURL(url);
         }
+
+        // --- Filtering ---------------------------------------------------------
+        // The mermaid source is split once into entity blocks and relation lines
+        // (the renderer's line format is stable); matching and neighbor expansion
+        // run on the structured `graph` payload.
+
+        const parsed = (function parseSource(src) {
+            const blocks = new Map();
+            const edges = [];
+            let current = null;
+            for (const line of src.split('\n')) {
+                const start = line.match(/^ {4}(\w+)\[/);
+                const edge = line.match(/^ {4}(\w+) \S+ (\w+) : /);
+                if (current) {
+                    blocks.get(current).push(line);
+                    if (line === '    }') current = null;
+                } else if (start) {
+                    current = start[1];
+                    blocks.set(current, [line]);
+                } else if (edge) {
+                    edges.push({ from: edge[1], to: edge[2], line: line });
+                }
+            }
+            return { blocks: blocks, edges: edges };
+        })(mermaidSource);
+
+        const totalTables = Object.keys(graph.tables).length;
+
+        function computeVisible(query) {
+            const q = query.trim().toLowerCase();
+            if (!q) return null;
+
+            const matched = new Set();
+            for (const [table, columns] of Object.entries(graph.tables)) {
+                if (table.toLowerCase().includes(q) || columns.some(c => c.toLowerCase().includes(q))) {
+                    matched.add(table);
+                }
+            }
+
+            const visible = new Set(matched);
+            for (const [from, to] of graph.edges) {
+                if (matched.has(from)) visible.add(to);
+                if (matched.has(to)) visible.add(from);
+            }
+
+            return visible;
+        }
+
+        function buildFilteredSource(visible) {
+            let columns = 0;
+            visible.forEach(t => columns += graph.tables[t].length);
+
+            let out = '---\ntitle: ' + visible.size + ' of ' + totalTables + ' tables · ' + columns + ' columns\n---\nerDiagram\n';
+            for (const [name, lines] of parsed.blocks) {
+                if (visible.has(name)) out += lines.join('\n') + '\n';
+            }
+            for (const edge of parsed.edges) {
+                if (visible.has(edge.from) && visible.has(edge.to)) out += edge.line + '\n';
+            }
+            return out;
+        }
+
+        let currentSource = mermaidSource;
+        let renderSeq = 0;
+
+        async function renderDiagram() {
+            resetView();
+            try {
+                const { svg } = await mermaid.render('erd-render-' + (++renderSeq), currentSource);
+                wrapper.innerHTML = svg;
+            } catch (e) {
+                wrapper.innerHTML = '<pre class="p-8 text-xs text-red-600">' + e.message + '</pre>';
+            }
+        }
+
+        const searchInput = document.getElementById('erd-search');
+        const countLabel = document.getElementById('erd-count');
+
+        function applyFilter(query) {
+            const visible = computeVisible(query);
+
+            const url = new URL(location);
+            if (query.trim()) url.searchParams.set('q', query.trim()); else url.searchParams.delete('q');
+            history.replaceState(null, '', url);
+
+            if (visible === null) {
+                countLabel.textContent = totalTables + ' tables';
+                currentSource = mermaidSource;
+                renderDiagram();
+                return;
+            }
+
+            countLabel.textContent = visible.size + ' / ' + totalTables + ' tables';
+
+            if (visible.size === 0) {
+                currentSource = '';
+                resetView();
+                wrapper.innerHTML = '<div class="p-8 text-sm text-gray-500">No tables or columns match.</div>';
+                return;
+            }
+
+            currentSource = buildFilteredSource(visible);
+            renderDiagram();
+        }
+
+        let debounceTimer;
+        searchInput.addEventListener('input', function() {
+            clearTimeout(debounceTimer);
+            debounceTimer = setTimeout(() => applyFilter(searchInput.value), 150);
+        });
+
+        searchInput.value = new URL(location).searchParams.get('q') || '';
+        applyFilter(searchInput.value);
     </script>
 
     <style>
-        pre.mermaid svg { display: block; max-width: none !important; }
+        #diagram-wrapper svg { display: block; max-width: none !important; }
     </style>
 </body>
 </html>

--- a/src/Http/MermaidErdController.php
+++ b/src/Http/MermaidErdController.php
@@ -14,24 +14,34 @@ class MermaidErdController
     public function __invoke(SchemaBuilder $builder): ViewContract
     {
         $connectionName = config('database.default');
-        $cacheKey = "mermaid-erd:diagram:{$connectionName}";
+        $cacheKey = "mermaid-erd:view:{$connectionName}";
 
-        $generate = fn (): string => (new MermaidErdRenderer)->render($builder->build());
+        $generate = function () use ($builder): array {
+            $schema = $builder->build();
+
+            return [
+                'diagram' => (new MermaidErdRenderer)->render($schema),
+                'graph' => $schema->toGraph(),
+            ];
+        };
 
         if (config('mermaid-erd.web.cache.enabled')) {
-            $diagram = Cache::remember(
+            $data = Cache::remember(
                 $cacheKey,
                 config('mermaid-erd.web.cache.ttl', 3600),
                 $generate,
             );
         } else {
-            $diagram = $generate();
+            $data = $generate();
         }
+
+        $jsonFlags = JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT;
 
         return View::make('mermaid-erd::diagram', [
             'connectionName' => $connectionName,
-            'diagram' => htmlspecialchars($diagram, ENT_QUOTES, 'UTF-8'),
-            'mermaidConfig' => json_encode(config('mermaid-erd.web.mermaid', []), JSON_THROW_ON_ERROR),
+            'diagram' => json_encode($data['diagram'], $jsonFlags),
+            'graph' => json_encode($data['graph'], $jsonFlags),
+            'mermaidConfig' => json_encode(config('mermaid-erd.web.mermaid', []), $jsonFlags),
         ]);
     }
 }

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -19,6 +19,32 @@ readonly class Schema
     }
 
     /**
+     * Lightweight graph representation for client-side filtering.
+     *
+     * @return array{tables: array<string, string[]>, edges: array<int, array{0: string, 1: string}>}
+     */
+    public function toGraph(): array
+    {
+        $tables = [];
+        foreach ($this->tables as $table) {
+            $tables[$table->name] = array_map(fn (Column $column): string => $column->name, $table->columns);
+        }
+
+        $edges = [];
+        $seen = [];
+        foreach ($this->relations as $relation) {
+            $key = "{$relation->from}|{$relation->to}";
+            if (isset($seen[$key])) {
+                continue;
+            }
+            $seen[$key] = true;
+            $edges[] = [$relation->from, $relation->to];
+        }
+
+        return ['tables' => $tables, 'edges' => $edges];
+    }
+
+    /**
      * Detected morph pairs without a configured morph relation, as "table.morphName".
      *
      * @return string[]

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -21,13 +21,17 @@ readonly class Schema
     /**
      * Lightweight graph representation for client-side filtering.
      *
-     * @return array{tables: array<string, string[]>, edges: array<int, array{0: string, 1: string}>}
+     * @return array{tables: array<string, string[]>, pivots: string[], edges: array<int, array{0: string, 1: string}>}
      */
     public function toGraph(): array
     {
         $tables = [];
+        $pivots = [];
         foreach ($this->tables as $table) {
             $tables[$table->name] = array_map(fn (Column $column): string => $column->name, $table->columns);
+            if ($table->pivot) {
+                $pivots[] = $table->name;
+            }
         }
 
         $edges = [];
@@ -41,7 +45,7 @@ readonly class Schema
             $edges[] = [$relation->from, $relation->to];
         }
 
-        return ['tables' => $tables, 'edges' => $edges];
+        return ['tables' => $tables, 'pivots' => $pivots, 'edges' => $edges];
     }
 
     /**

--- a/tests/MermaidErdWebRouteTest.php
+++ b/tests/MermaidErdWebRouteTest.php
@@ -13,6 +13,7 @@ it('uses the diagram blade view', function (): void {
     $response->assertViewIs('mermaid-erd::diagram');
     $response->assertViewHas('connectionName');
     $response->assertViewHas('diagram');
+    $response->assertViewHas('graph');
     $response->assertViewHas('mermaidConfig');
 });
 
@@ -22,8 +23,17 @@ it('contains required html structure', function (): void {
     $response->assertOk();
     $response->assertSee('<!DOCTYPE html>', false);
     $response->assertSee('mermaid.min.js', false);
-    $response->assertSee('<pre class="mermaid', false);
+    $response->assertSee('id="diagram-wrapper"', false);
     $response->assertSee('tailwindcss', false);
+});
+
+it('contains the filter search box and graph payload', function (): void {
+    $response = $this->get('/mermaid-erd');
+
+    $response->assertOk();
+    $response->assertSee('id="erd-search"', false);
+    $response->assertSee('const graph =', false);
+    $response->assertSee('"edges":', false);
 });
 
 it('contains diagram with table names', function (): void {
@@ -62,7 +72,7 @@ it('does not cache when cache is disabled', function (): void {
     $this->get('/mermaid-erd')->assertOk();
 
     $connectionName = config('database.default');
-    expect(Cache::has("mermaid-erd:diagram:{$connectionName}"))->toBeFalse();
+    expect(Cache::has("mermaid-erd:view:{$connectionName}"))->toBeFalse();
 });
 
 it('caches diagram when cache is enabled', function (): void {
@@ -72,7 +82,7 @@ it('caches diagram when cache is enabled', function (): void {
     $this->get('/mermaid-erd')->assertOk();
 
     $connectionName = config('database.default');
-    expect(Cache::has("mermaid-erd:diagram:{$connectionName}"))->toBeTrue();
+    expect(Cache::has("mermaid-erd:view:{$connectionName}"))->toBeTrue();
 });
 
 it('has named route mermaid-erd', function (): void {

--- a/tests/SchemaBuilderTest.php
+++ b/tests/SchemaBuilderTest.php
@@ -102,9 +102,18 @@ it('builds morph relations from configured mappings', function (): void {
     expect($morphs->pluck('from')->all())->toBe(['posts', 'videos'])
         ->and($morphs->first()->to)->toBe('reviews')
         ->and($morphs->first()->morphName)->toBe('reviewable')
-        ->and($schema->unmappedMorphs())->toBe([]);
+        ->and($schema->unmappedMorphs())->not->toContain('reviews.reviewable');
 });
 
 it('reports unmapped morph pairs', function (): void {
-    expect(buildSchema()->unmappedMorphs())->toBe(['reviews.reviewable']);
+    expect(buildSchema()->unmappedMorphs())->toBe(['attachments.attachable', 'reviews.reviewable']);
+});
+
+it('exposes a graph representation for filtering', function (): void {
+    $graph = buildSchema()->toGraph();
+
+    expect($graph['tables']['users'])->toBe(['id', 'name', 'email', 'created_at', 'updated_at'])
+        ->and($graph['edges'])->toContain(['posts', 'comments'])
+        ->and($graph['edges'])->toContain(['users', 'ai_messages'])
+        ->and(collect($graph['edges'])->duplicates()->all())->toBe([]);
 });

--- a/tests/SchemaBuilderTest.php
+++ b/tests/SchemaBuilderTest.php
@@ -113,6 +113,9 @@ it('exposes a graph representation for filtering', function (): void {
     $graph = buildSchema()->toGraph();
 
     expect($graph['tables']['users'])->toBe(['id', 'name', 'email', 'created_at', 'updated_at'])
+        ->and($graph['pivots'])->toContain('post_tag')
+        ->and($graph['pivots'])->toContain('coupon_order')
+        ->and($graph['pivots'])->not->toContain('stocks')
         ->and($graph['edges'])->toContain(['posts', 'comments'])
         ->and($graph['edges'])->toContain(['users', 'ai_messages'])
         ->and(collect($graph['edges'])->duplicates()->all())->toBe([]);

--- a/workbench/database/migrations/0001_01_01_000010_create_customers_table.php
+++ b/workbench/database/migrations/0001_01_01_000010_create_customers_table.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('customers', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('phone')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('customers');
+    }
+};

--- a/workbench/database/migrations/0001_01_01_000011_create_addresses_table.php
+++ b/workbench/database/migrations/0001_01_01_000011_create_addresses_table.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('addresses', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('customer_id')->constrained('customers')->cascadeOnDelete();
+            $table->string('type')->default('shipping');
+            $table->string('street');
+            $table->string('city');
+            $table->string('zip');
+            $table->string('country');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('addresses');
+    }
+};

--- a/workbench/database/migrations/0001_01_01_000012_create_suppliers_table.php
+++ b/workbench/database/migrations/0001_01_01_000012_create_suppliers_table.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('suppliers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('phone')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('suppliers');
+    }
+};

--- a/workbench/database/migrations/0001_01_01_000013_create_warehouses_table.php
+++ b/workbench/database/migrations/0001_01_01_000013_create_warehouses_table.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('warehouses', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('code')->unique();
+            $table->string('address')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('warehouses');
+    }
+};

--- a/workbench/database/migrations/0001_01_01_000014_create_products_table.php
+++ b/workbench/database/migrations/0001_01_01_000014_create_products_table.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('products', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('supplier_id')->constrained('suppliers')->cascadeOnDelete();
+            $table->foreignId('category_id')->nullable()->constrained('categories')->nullOnDelete();
+            $table->string('name');
+            $table->string('sku')->unique();
+            $table->integer('price');
+            $table->text('description')->nullable();
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('products');
+    }
+};

--- a/workbench/database/migrations/0001_01_01_000015_create_product_variants_table.php
+++ b/workbench/database/migrations/0001_01_01_000015_create_product_variants_table.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('product_variants', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('product_id')->constrained('products')->cascadeOnDelete();
+            $table->string('sku')->unique();
+            $table->string('options')->nullable();
+            $table->integer('price')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('product_variants');
+    }
+};

--- a/workbench/database/migrations/0001_01_01_000016_create_stocks_table.php
+++ b/workbench/database/migrations/0001_01_01_000016_create_stocks_table.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('stocks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('warehouse_id')->constrained('warehouses')->cascadeOnDelete();
+            $table->foreignId('product_variant_id')->constrained('product_variants')->cascadeOnDelete();
+            $table->integer('quantity')->default('0');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('stocks');
+    }
+};

--- a/workbench/database/migrations/0001_01_01_000017_create_orders_table.php
+++ b/workbench/database/migrations/0001_01_01_000017_create_orders_table.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('orders', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('customer_id')->constrained('customers')->cascadeOnDelete();
+            $table->string('number')->unique();
+            $table->string('status')->default('pending');
+            $table->integer('total');
+            $table->timestamp('placed_at')->nullable();
+            $table->softDeletes();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('orders');
+    }
+};

--- a/workbench/database/migrations/0001_01_01_000018_create_order_items_table.php
+++ b/workbench/database/migrations/0001_01_01_000018_create_order_items_table.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('order_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_id')->constrained('orders')->cascadeOnDelete();
+            $table->foreignId('product_variant_id')->constrained('product_variants')->restrictOnDelete();
+            $table->integer('quantity');
+            $table->integer('unit_price');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('order_items');
+    }
+};

--- a/workbench/database/migrations/0001_01_01_000019_create_coupons_table.php
+++ b/workbench/database/migrations/0001_01_01_000019_create_coupons_table.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('coupons', function (Blueprint $table) {
+            $table->id();
+            $table->string('code')->unique();
+            $table->integer('discount');
+            $table->timestamp('valid_until')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('coupons');
+    }
+};

--- a/workbench/database/migrations/0001_01_01_000020_create_coupon_order_table.php
+++ b/workbench/database/migrations/0001_01_01_000020_create_coupon_order_table.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('coupon_order', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('coupon_id')->constrained('coupons')->cascadeOnDelete();
+            $table->foreignId('order_id')->constrained('orders')->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('coupon_order');
+    }
+};

--- a/workbench/database/migrations/0001_01_01_000021_create_payments_table.php
+++ b/workbench/database/migrations/0001_01_01_000021_create_payments_table.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_id')->constrained('orders')->cascadeOnDelete();
+            $table->string('method');
+            $table->integer('amount');
+            $table->timestamp('paid_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payments');
+    }
+};

--- a/workbench/database/migrations/0001_01_01_000022_create_invoices_table.php
+++ b/workbench/database/migrations/0001_01_01_000022_create_invoices_table.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('invoices', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_id')->unique()->constrained('orders')->cascadeOnDelete();
+            $table->string('number')->unique();
+            $table->timestamp('issued_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('invoices');
+    }
+};

--- a/workbench/database/migrations/0001_01_01_000023_create_shipments_table.php
+++ b/workbench/database/migrations/0001_01_01_000023_create_shipments_table.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('shipments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_id')->constrained('orders')->cascadeOnDelete();
+            $table->foreignId('warehouse_id')->constrained('warehouses')->restrictOnDelete();
+            $table->string('tracking_number')->nullable();
+            $table->timestamp('shipped_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('shipments');
+    }
+};

--- a/workbench/database/migrations/0001_01_01_000024_create_shipment_items_table.php
+++ b/workbench/database/migrations/0001_01_01_000024_create_shipment_items_table.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('shipment_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('shipment_id')->constrained('shipments')->cascadeOnDelete();
+            $table->foreignId('order_item_id')->constrained('order_items')->cascadeOnDelete();
+            $table->integer('quantity');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('shipment_items');
+    }
+};

--- a/workbench/database/migrations/0001_01_01_000025_create_attachments_table.php
+++ b/workbench/database/migrations/0001_01_01_000025_create_attachments_table.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('attachments', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('attachable');
+            $table->string('path');
+            $table->string('mime_type')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('attachments');
+    }
+};

--- a/workbench/database/migrations/0001_01_01_000026_create_audit_logs_table.php
+++ b/workbench/database/migrations/0001_01_01_000026_create_audit_logs_table.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('user_id');
+            $table->string('action');
+            $table->text('payload')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('audit_logs');
+    }
+};


### PR DESCRIPTION
Builds on #18: filtering is a graph operation on the schema model, executed client-side for instant UX.

**Filter**
- `Schema::toGraph()` exposes `{tables: {name: [columns]}, edges: [[from, to]]}`; the controller embeds it next to the mermaid source (cached together under a new cache key).
- Search box filters live: tables matching by **name or column name** stay visible together with their directly connected neighbors (1 hop). Title becomes `x of n tables`, counter in the header, empty state for no matches.
- `?q=` is synced to the URL — filtered views are shareable/deep-linkable.
- Copy Mermaid / Download SVG export exactly the filtered diagram.
- Bugfix on the way: Copy Mermaid used to copy HTML-escaped source (`&quot;`) because the escaped string was passed to `json_encode`.

**Big workbench example**
26 tables (was 9): an e-commerce extension (customers, orders, order_items, products, variants, stock, warehouses, suppliers, payments, invoices, shipments, coupons, …) cross-linked into the existing blog schema. It deliberately exercises every relation kind: one-to-one (`invoices.order_id` unique), true pivot (`coupon_order`), join table with payload (`stocks`), second morph pair (`attachments`), guessed relation (`audit_logs.user_id`). Try it: `composer start`, then search `orders` or `deleted_at`.

The README example ERD stays scoped to the original blog tables (regenerated with `--tables`, zero diff).

**Verification**
- 56 tests green (new: graph payload shape, filter UI/payload in the route response).
- The JS matching/expansion and source-parsing functions were run in node against the real 26-table graph and rendered source: block/edge counts align with the payload, 1-hop semantics confirmed (e.g. `orders` pulls `coupon_order` but not `coupons`).