### PR TITLE
Raise PHPStan to level 8

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: 8
     paths:
         - src
         - config

--- a/src/Commands/LaravelMermaidErdCommand.php
+++ b/src/Commands/LaravelMermaidErdCommand.php
@@ -24,12 +24,10 @@ class LaravelMermaidErdCommand extends Command
 
     public function handle(): int
     {
-        $connectionName = $this->option('connection');
-        $connection = $this->laravel->make('db')->connection($connectionName);
+        $connection = $this->laravel->make('db')->connection($this->stringOption('connection'));
 
-        $onlyTables = $this->option('tables')
-            ? array_map(trim(...), explode(',', $this->option('tables')))
-            : [];
+        $tables = $this->stringOption('tables');
+        $onlyTables = $tables !== null ? array_map(trim(...), explode(',', $tables)) : [];
 
         $service = new DatabaseInformationService(
             $connection,
@@ -45,7 +43,7 @@ class LaravelMermaidErdCommand extends Command
         );
         $diagram = (new MermaidErdRenderer)->render($builder->build());
 
-        $output = $this->option('output') ?? select(
+        $output = $this->stringOption('output') ?? select(
             label: 'How would you like to output the diagram?',
             options: ['stdout', 'file'],
             default: 'stdout',
@@ -67,7 +65,7 @@ class LaravelMermaidErdCommand extends Command
 
     private function outputToFile(string $diagram): int
     {
-        $path = $this->option('path') ?? text(
+        $path = $this->stringOption('path') ?? text(
             label: 'Where should the diagram be saved?',
             default: 'README.md',
             required: true,
@@ -83,5 +81,12 @@ class LaravelMermaidErdCommand extends Command
         $this->info("Diagram written to {$path}");
 
         return self::SUCCESS;
+    }
+
+    private function stringOption(string $key): ?string
+    {
+        $value = $this->option($key);
+
+        return is_string($value) && $value !== '' ? $value : null;
     }
 }

--- a/src/DatabaseInformationService.php
+++ b/src/DatabaseInformationService.php
@@ -4,8 +4,19 @@ namespace Bambamboole\LaravelMermaidErd;
 
 use Illuminate\Database\Connection;
 
+/**
+ * Shapes as returned by Laravel's schema builder (unsealed — drivers add keys).
+ *
+ * @phpstan-type ForeignKeyRow array{columns: string[], foreign_table: string, on_delete: string|null, ...}
+ * @phpstan-type ColumnRow array{name: string, type_name: string, nullable: bool, default: string|null, ...}
+ * @phpstan-type IndexRow array{columns: string[], primary: bool, unique: bool, ...}
+ */
 class DatabaseInformationService
 {
+    /**
+     * @param  string[]  $ignoreTables
+     * @param  string[]  $onlyTables
+     */
     public function __construct(
         private readonly Connection $db,
         private readonly array $ignoreTables = [],
@@ -13,6 +24,9 @@ class DatabaseInformationService
         private readonly ?string $schema = null,
     ) {}
 
+    /**
+     * @return string[]
+     */
     public function getTables(): array
     {
         $tables = $this->db->getSchemaBuilder()->getTables($this->getSchemaName());
@@ -25,16 +39,25 @@ class DatabaseInformationService
         return array_values(array_filter($tableNames, fn (string $tableName): bool => !in_array($tableName, $this->ignoreTables)));
     }
 
+    /**
+     * @return list<ForeignKeyRow>
+     */
     public function getForeignKeys(string $table): array
     {
         return $this->db->getSchemaBuilder()->getForeignKeys($table);
     }
 
+    /**
+     * @return list<ColumnRow>
+     */
     public function getColumns(string $table): array
     {
         return $this->db->getSchemaBuilder()->getColumns($table);
     }
 
+    /**
+     * @return list<IndexRow>
+     */
     public function getIndexes(string $table): array
     {
         return $this->db->getSchemaBuilder()->getIndexes($table);

--- a/src/FileWriter.php
+++ b/src/FileWriter.php
@@ -30,7 +30,8 @@ class FileWriter
             $pattern = '/'.preg_quote(self::START_TAG, '/').'.*?'.preg_quote(self::END_TAG, '/').'/s';
             // Only fill the first tag pair so later pairs (e.g. a usage example
             // documenting the tags) are left untouched.
-            $content = preg_replace_callback($pattern, fn (): string => $mermaidBlock, $content, 1);
+            $content = preg_replace_callback($pattern, fn (): string => $mermaidBlock, $content, 1)
+                ?? throw new \RuntimeException("Failed to replace the ERD block in {$path}");
         } else {
             $content = rtrim($content)."\n\n## ERD\n\n{$mermaidBlock}\n";
         }

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -5,10 +5,18 @@ namespace Bambamboole\LaravelMermaidErd\Schema;
 use Bambamboole\LaravelMermaidErd\DatabaseInformationService;
 use Illuminate\Support\Str;
 
+/**
+ * @phpstan-import-type ForeignKeyRow from DatabaseInformationService
+ *
+ * @phpstan-type TableMeta array{foreignKeys: list<ForeignKeyRow>, uniqueColumns: string[], nullableColumns: string[], foreignKeyColumns: string[], polymorphicColumns: string[]}
+ */
 class SchemaBuilder
 {
     private const array PIVOT_EXTRA_COLUMNS = ['id', 'created_at', 'updated_at'];
 
+    /**
+     * @param  array<string, string[]>  $polymorphicRelationships
+     */
     public function __construct(
         private readonly DatabaseInformationService $databaseInformationService,
         private readonly array $polymorphicRelationships = [],
@@ -86,6 +94,12 @@ class SchemaBuilder
         return new Schema($tables, $this->buildRelations($tableNames, $tables, $meta));
     }
 
+    /**
+     * @param  string[]  $tableNames
+     * @param  array<string, Table>  $tables
+     * @param  array<string, TableMeta>  $meta
+     * @return list<Relation>
+     */
     private function buildRelations(array $tableNames, array $tables, array $meta): array
     {
         $relations = [];
@@ -130,6 +144,12 @@ class SchemaBuilder
         return $relations;
     }
 
+    /**
+     * @param  string[]  $tableNames
+     * @param  array<string, Table>  $tables
+     * @param  array<string, TableMeta>  $meta
+     * @return list<Relation>
+     */
     private function guessRelations(string $tableName, array $tableNames, array $tables, array $meta): array
     {
         $relations = [];
@@ -166,6 +186,7 @@ class SchemaBuilder
     }
 
     /**
+     * @param  string[]  $columnNames
      * @return array{0: string[], 1: string[]} [morph names, participating column names]
      */
     private function detectMorphs(array $columnNames): array
@@ -191,6 +212,11 @@ class SchemaBuilder
         return [$morphNames, $polymorphicColumns];
     }
 
+    /**
+     * @param  list<ForeignKeyRow>  $foreignKeys
+     * @param  string[]  $columnNames
+     * @param  string[]  $foreignKeyColumns
+     */
     private function isPivot(array $foreignKeys, array $columnNames, array $foreignKeyColumns): bool
     {
         if (count($foreignKeys) !== 2) {


### PR DESCRIPTION
The schema-model refactor (#18) shrank the gap from level 5 to max considerably. This closes it to level 8:

- Laravel's schema row shapes (`ForeignKeyRow`, `ColumnRow`, `IndexRow`) are documented once as unsealed phpstan types on `DatabaseInformationService` and imported in `SchemaBuilder` — useful contributor docs, not just annotations.
- Level 8 surfaced one real issue: `FileWriter` passed a possible `preg_replace_callback` null (PCRE failure) into `Filesystem::put()`, which would have silently emptied the target file. It now throws.

`composer check` green: pint, PHPStan level 8, rector, 56 tests.