### PR TITLE
Raw endpoint, --exclude-tables, .mmd output, zoom-to-cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Writes the diagram to the specified file (defaults to `README.md`). The file out
 - **File has tags**: replaces content between the tags
 - **File exists without tags**: appends an `## ERD` section with the diagram
 - **File doesn't exist**: creates it with the diagram
+- **Path ends in `.mmd`**: writes the plain Mermaid source without any markdown wrapper
 
 Add these tags where you want the diagram to appear:
 
@@ -167,6 +168,14 @@ Only include specific tables (comma-separated):
 
 ```bash
 php artisan generate:mermaid-erd --output=stdout --tables=users,posts,comments
+```
+
+#### `--exclude-tables`
+
+Exclude specific tables, on top of the configured ignore list:
+
+```bash
+php artisan generate:mermaid-erd --output=stdout --exclude-tables=audit_logs,ai_messages
 ```
 
 ### Configuration
@@ -198,7 +207,9 @@ The generator automatically detects pivot tables (tables with exactly 2 foreign 
 
 The package also ships a web view that renders the diagram in the browser using Mermaid.js. It is enabled by default at `/mermaid-erd` and configurable via the `web` section of the config file.
 
-The view has a search box that filters the diagram live: type a table or column name and only matching tables plus their directly connected neighbors stay visible. Pivot tables are treated as pass-throughs — a many-to-many counts as one relation, so both of its sides stay visible. The query is kept in the URL (`?q=orders`), so filtered views are shareable, and "Copy Mermaid" / "Download SVG" export exactly what is on screen.
+The view has a search box that filters the diagram live: type a table or column name and only matching tables plus their directly connected neighbors stay visible. Pivot tables are treated as pass-throughs — a many-to-many counts as one relation, so both of its sides stay visible.
+
+Append `?raw=1` to the route to get the plain Mermaid source as `text/plain` — handy for scripts or pasting into [mermaid.live](https://mermaid.live). The query is kept in the URL (`?q=orders`), so filtered views are shareable, and "Copy Mermaid" / "Download SVG" export exactly what is on screen.
 
 ```php
 'web' => [

--- a/resources/views/diagram.blade.php
+++ b/resources/views/diagram.blade.php
@@ -71,8 +71,18 @@
             zoomLabel.textContent = Math.round(scale * 100) + '%';
         }
 
-        function zoomIn()  { scale = Math.min(MAX_ZOOM, scale + ZOOM_STEP); applyTransform(); }
-        function zoomOut() { scale = Math.max(MIN_ZOOM, scale - ZOOM_STEP); applyTransform(); }
+        // Zoom keeping the container point (px, py) fixed on screen.
+        function zoomAt(px, py, newScale) {
+            newScale = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, newScale));
+            const ratio = newScale / scale;
+            translateX = px - ratio * (px - translateX);
+            translateY = py - ratio * (py - translateY);
+            scale = newScale;
+            applyTransform();
+        }
+
+        function zoomIn()  { zoomAt(container.clientWidth / 2, container.clientHeight / 2, scale + ZOOM_STEP); }
+        function zoomOut() { zoomAt(container.clientWidth / 2, container.clientHeight / 2, scale - ZOOM_STEP); }
         function resetView() { scale = 1; translateX = 0; translateY = 0; applyTransform(); }
 
         container.addEventListener('wheel', function(e) {
@@ -81,8 +91,8 @@
             // small deltas (smooth glide), a mouse wheel notch (~100) matches
             // roughly the old 15% step. deltaMode 1 means line-based deltas.
             const delta = e.deltaMode === 1 ? e.deltaY * 24 : e.deltaY;
-            scale = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, scale * Math.exp(-delta * 0.002)));
-            applyTransform();
+            const rect = container.getBoundingClientRect();
+            zoomAt(e.clientX - rect.left, e.clientY - rect.top, scale * Math.exp(-delta * 0.002));
         }, { passive: false });
 
         container.addEventListener('mousedown', function(e) {

--- a/src/Commands/LaravelMermaidErdCommand.php
+++ b/src/Commands/LaravelMermaidErdCommand.php
@@ -18,7 +18,8 @@ class LaravelMermaidErdCommand extends Command
         {--output= : Output mode: stdout or file}
         {--path= : File path for "file" output mode}
         {--connection= : Database connection to use}
-        {--tables= : Comma-separated list of tables to include}';
+        {--tables= : Comma-separated list of tables to include}
+        {--exclude-tables= : Comma-separated list of tables to exclude, on top of the configured ignore list}';
 
     protected $description = 'Generate a Mermaid.js ER diagram from the database schema';
 
@@ -29,9 +30,15 @@ class LaravelMermaidErdCommand extends Command
         $tables = $this->stringOption('tables');
         $onlyTables = $tables !== null ? array_map(trim(...), explode(',', $tables)) : [];
 
+        $excludeTables = $this->stringOption('exclude-tables');
+        $ignoreTables = array_merge(
+            config('mermaid-erd.ignore_tables', []),
+            $excludeTables !== null ? array_map(trim(...), explode(',', $excludeTables)) : [],
+        );
+
         $service = new DatabaseInformationService(
             $connection,
-            config('mermaid-erd.ignore_tables', []),
+            $ignoreTables,
             $onlyTables,
             config('mermaid-erd.schema'),
         );

--- a/src/FileWriter.php
+++ b/src/FileWriter.php
@@ -16,6 +16,12 @@ class FileWriter
 
     public function write(string $path, string $diagram): void
     {
+        if (str_ends_with($path, '.mmd')) {
+            $this->filesystem->put($path, $diagram);
+
+            return;
+        }
+
         $mermaidBlock = self::START_TAG."\n```mermaid\n{$diagram}```\n".self::END_TAG;
 
         if (!$this->filesystem->exists($path)) {

--- a/src/Http/MermaidErdController.php
+++ b/src/Http/MermaidErdController.php
@@ -6,12 +6,14 @@ namespace Bambamboole\LaravelMermaidErd\Http;
 use Bambamboole\LaravelMermaidErd\MermaidErdRenderer;
 use Bambamboole\LaravelMermaidErd\Schema\SchemaBuilder;
 use Illuminate\Contracts\View\View as ViewContract;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\View;
 
 class MermaidErdController
 {
-    public function __invoke(SchemaBuilder $builder): ViewContract
+    public function __invoke(Request $request, SchemaBuilder $builder): ViewContract|Response
     {
         $connectionName = config('database.default');
         $cacheKey = "mermaid-erd:view:{$connectionName}";
@@ -33,6 +35,10 @@ class MermaidErdController
             );
         } else {
             $data = $generate();
+        }
+
+        if ($request->boolean('raw')) {
+            return new Response($data['diagram'], 200, ['Content-Type' => 'text/plain; charset=UTF-8']);
         }
 
         $jsonFlags = JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT;

--- a/tests/LaravelMermaidErdCommandTest.php
+++ b/tests/LaravelMermaidErdCommandTest.php
@@ -182,6 +182,35 @@ it('supports the --tables option', function (): void {
         ->not->toMatch('/post_tag\[.*?\] \{/');
 });
 
+it('supports the --exclude-tables option', function (): void {
+    Artisan::call('generate:mermaid-erd', ['--output' => 'stdout', '--exclude-tables' => 'comments,tags']);
+
+    $output = Artisan::output();
+
+    expect($output)
+        ->toMatch('/users\[.*?\] \{/')
+        ->toMatch('/posts\[.*?\] \{/')
+        ->not->toMatch('/comments\[.*?\] \{/')
+        ->not->toMatch('/tags\[.*?\] \{/');
+});
+
+it('writes plain mermaid source when the path ends in .mmd', function (): void {
+    $path = tempnam(sys_get_temp_dir(), 'mermaid_test_').'.mmd';
+
+    $this->artisan('generate:mermaid-erd', ['--output' => 'file', '--path' => $path])
+        ->assertSuccessful();
+
+    $content = file_get_contents($path);
+
+    expect($content)
+        ->toStartWith("---\ntitle:")
+        ->toContain('erDiagram')
+        ->not->toContain('<!-- mermaid-erd-start -->')
+        ->not->toContain('```');
+
+    unlink($path);
+});
+
 it('renders pivot tables as full entities with FK columns', function (): void {
     Artisan::call('generate:mermaid-erd', ['--output' => 'stdout']);
     $output = Artisan::output();

--- a/tests/MermaidErdWebRouteTest.php
+++ b/tests/MermaidErdWebRouteTest.php
@@ -27,6 +27,17 @@ it('contains required html structure', function (): void {
     $response->assertSee('tailwindcss', false);
 });
 
+it('returns plain mermaid source with ?raw=1', function (): void {
+    $response = $this->get('/mermaid-erd?raw=1');
+
+    $response->assertOk();
+    $response->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
+    expect($response->getContent())
+        ->toStartWith("---\ntitle:")
+        ->toContain('erDiagram')
+        ->not->toContain('<html');
+});
+
 it('contains the filter search box and graph payload', function (): void {
     $response = $this->get('/mermaid-erd');
 


### PR DESCRIPTION
Four small quality-of-life features:

- **`?raw=1`** on the web route returns the plain Mermaid source as `text/plain` — for scripts, CI, or pasting into mermaid.live. Shares the cached payload with the HTML view.
- **`--exclude-tables`** CLI option — comma-separated tables to drop, merged on top of the configured ignore list (mirror of `--tables`).
- **`.mmd` file output** — `--path=schema.mmd` writes the raw Mermaid source without the markdown wrapper and marker tags.
- **Zoom-to-cursor** in the web view — wheel zoom keeps the point under the cursor fixed instead of scaling from the top-left origin; the +/− buttons anchor on the viewport center.

59 tests green (3 new), full `composer check` gate passes.