### PR TITLE
Enrich the diagram with Eloquent model metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ erDiagram
         datetime created_at "nullable"
         datetime updated_at "nullable"
     }
-    posts["posts (6)"] {
+    posts["posts (6) · Post"] {
         integer id PK
         integer user_id FK
         varchar title
@@ -55,7 +55,7 @@ erDiagram
         datetime created_at "nullable"
         datetime updated_at "nullable"
     }
-    reviews["reviews (8)"] {
+    reviews["reviews (8) · Review"] {
         integer id PK
         varchar reviewable_type "polymorphic"
         integer reviewable_id "polymorphic"
@@ -72,18 +72,18 @@ erDiagram
         datetime created_at "nullable"
         datetime updated_at "nullable"
     }
-    users["users (5)"] {
+    users["users (5) · User"] {
         integer id PK
         varchar name
         varchar email UK
         datetime created_at "nullable"
         datetime updated_at "nullable"
     }
-    videos["videos (6)"] {
+    videos["videos (6) · Video"] {
         integer id PK
         varchar title
         varchar url
-        datetime deleted_at "soft-delete, nullable"
+        datetime deleted_at "soft-delete, cast: datetime, nullable"
         datetime created_at "nullable"
         datetime updated_at "nullable"
     }
@@ -95,8 +95,8 @@ erDiagram
     posts ||--o{ post_tag : "pivot, has many via post_id, cascade delete"
     users ||--o{ posts : "has many via user_id, cascade delete"
     users ||--o{ reviews : "has many via user_id, cascade delete"
-%% Unmapped polymorphic relations (add to config 'mermaid-erd.polymorphic_relationships'):
-%%   reviews.reviewable (reviewable_type + reviewable_id)
+    posts ||--o{ reviews : "morphMany via reviewable"
+    videos ||--o{ reviews : "morphMany via reviewable"
 ```
 <!-- mermaid-erd-end -->
 
@@ -198,6 +198,25 @@ return [
 By default, MySQL connections are scoped to the active database name so tables
 from other visible databases are not included in the diagram. Set `schema` if you
 want to inspect a specific schema/database explicitly.
+
+### Model metadata
+
+When enabled (the default), the package scans your Eloquent models and enriches the diagram with what only the code knows:
+
+- the owning model class in each table header (`orders (9) · Order`)
+- casts, accessors and mutators as column annotations (`varchar status "cast: OrderStatus"`)
+- polymorphic relations, auto-discovered from `morphOne` / `morphMany` / `morphToMany` methods — no manual `polymorphic_relationships` config needed for them
+
+Only relation methods with an **explicit return type** are invoked (and each call is failure-isolated), so the scan never executes arbitrary model code. Configure it via:
+
+```php
+'models' => [
+    'enabled' => true,
+    'paths' => null, // null defaults to [app_path('Models')]
+],
+```
+
+The `polymorphic_relationships` config still works and is merged on top — use it for morphs the scan cannot see (untyped relation methods, external packages).
 
 ### Smart relationship detection
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Generated from this package's own test schema:
 title: 9 tables · 52 columns
 ---
 erDiagram
-    ai_messages["ai_messages (6)"] {
+    ai_messages["ai_messages (6) · AiMessage"] {
         integer id PK
         integer user_id
         text prompt
@@ -87,7 +87,7 @@ erDiagram
         datetime created_at "nullable"
         datetime updated_at "nullable"
     }
-    users ||--o{ ai_messages : "guessed has many via user_id"
+    users ||--o{ ai_messages : "hasMany via user_id"
     categories |o--o{ categories : "self-ref via parent_id, set null delete"
     users ||--o{ comments : "has many via user_id, cascade delete"
     posts ||--o{ comments : "has many via post_id, cascade delete"
@@ -206,13 +206,14 @@ When enabled (the default), the package scans your Eloquent models and enriches 
 - the owning model class in each table header (`orders (9) · Order`)
 - casts, accessors and mutators as column annotations (`varchar status "cast: OrderStatus"`)
 - polymorphic relations, auto-discovered from `morphOne` / `morphMany` / `morphToMany` methods — no manual `polymorphic_relationships` config needed for them
+- `hasMany` / `hasOne` / `belongsTo` relations for columns without a foreign key constraint — rendered with the declaring method (`hasMany via user_id`) and replacing the name-based guess. Precedence: foreign key constraint > model relation > guess.
 
 Only relation methods with an **explicit return type** are invoked (and each call is failure-isolated), so the scan never executes arbitrary model code. Configure it via:
 
 ```php
 'models' => [
     'enabled' => true,
-    'paths' => null, // null defaults to [app_path('Models')]
+    'paths' => null, // null defaults to [app_path()]
 ],
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "php": "^8.3",
         "illuminate/contracts": "^12.0||^13.0",
         "laravel/prompts": "^0.3",
-        "spatie/laravel-package-tools": "^1.16"
+        "spatie/laravel-package-tools": "^1.16",
+        "spatie/php-structure-discoverer": "^2.4"
     },
     "require-dev": {
         "laravel/boost": "^2.4",

--- a/config/mermaid-erd.php
+++ b/config/mermaid-erd.php
@@ -17,6 +17,16 @@ return [
 
     'guess_relationships' => true,
 
+    'models' => [
+        // Scan Eloquent models to annotate tables (model class), columns
+        // (casts, accessors, mutators) and auto-discover polymorphic relations
+        // from typed morphOne/morphMany/morphToMany methods.
+        'enabled' => true,
+
+        // Directories to scan. null defaults to [app_path('Models')].
+        'paths' => null,
+    ],
+
     'polymorphic_relationships' => [
         // 'table.morph_name' => [target_tables]
         // 'comments.commentable' => ['posts', 'videos'],

--- a/config/mermaid-erd.php
+++ b/config/mermaid-erd.php
@@ -19,11 +19,11 @@ return [
 
     'models' => [
         // Scan Eloquent models to annotate tables (model class), columns
-        // (casts, accessors, mutators) and auto-discover polymorphic relations
-        // from typed morphOne/morphMany/morphToMany methods.
+        // (casts, accessors, mutators) and auto-discover relations from typed
+        // relation methods (hasMany/hasOne/belongsTo/morphOne/morphMany/morphToMany).
         'enabled' => true,
 
-        // Directories to scan. null defaults to [app_path('Models')].
+        // Directories to scan. null defaults to [app_path()].
         'paths' => null,
     ],
 

--- a/resources/views/diagram.blade.php
+++ b/resources/views/diagram.blade.php
@@ -175,7 +175,8 @@
 
             const matched = new Set();
             for (const [table, columns] of Object.entries(graph.tables)) {
-                if (table.toLowerCase().includes(q) || columns.some(c => c.toLowerCase().includes(q))) {
+                const model = (graph.models[table] || '').toLowerCase();
+                if (table.toLowerCase().includes(q) || model.includes(q) || columns.some(c => c.toLowerCase().includes(q))) {
                     matched.add(table);
                 }
             }

--- a/src/Commands/LaravelMermaidErdCommand.php
+++ b/src/Commands/LaravelMermaidErdCommand.php
@@ -5,6 +5,7 @@ namespace Bambamboole\LaravelMermaidErd\Commands;
 use Bambamboole\LaravelMermaidErd\DatabaseInformationService;
 use Bambamboole\LaravelMermaidErd\FileWriter;
 use Bambamboole\LaravelMermaidErd\MermaidErdRenderer;
+use Bambamboole\LaravelMermaidErd\Schema\ModelScanner;
 use Bambamboole\LaravelMermaidErd\Schema\SchemaBuilder;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
@@ -47,6 +48,7 @@ class LaravelMermaidErdCommand extends Command
             $service,
             config('mermaid-erd.polymorphic_relationships', []),
             config('mermaid-erd.guess_relationships', true),
+            config('mermaid-erd.models.enabled', true) ? $this->laravel->make(ModelScanner::class)->scan() : null,
         );
         $diagram = (new MermaidErdRenderer)->render($builder->build());
 

--- a/src/LaravelMermaidErdServiceProvider.php
+++ b/src/LaravelMermaidErdServiceProvider.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 namespace Bambamboole\LaravelMermaidErd;
 
 use Bambamboole\LaravelMermaidErd\Commands\LaravelMermaidErdCommand;
+use Bambamboole\LaravelMermaidErd\Schema\ModelScanner;
 use Bambamboole\LaravelMermaidErd\Schema\SchemaBuilder;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -28,10 +29,15 @@ class LaravelMermaidErdServiceProvider extends PackageServiceProvider
             config('mermaid-erd.schema'),
         ));
 
+        $this->app->bind(ModelScanner::class, fn (): ModelScanner => new ModelScanner(
+            config('mermaid-erd.models.paths') ?? [app_path('Models')],
+        ));
+
         $this->app->bind(SchemaBuilder::class, fn ($app): SchemaBuilder => new SchemaBuilder(
             $app->make(DatabaseInformationService::class),
             config('mermaid-erd.polymorphic_relationships', []),
             config('mermaid-erd.guess_relationships', true),
+            config('mermaid-erd.models.enabled', true) ? $app->make(ModelScanner::class)->scan() : null,
         ));
     }
 }

--- a/src/LaravelMermaidErdServiceProvider.php
+++ b/src/LaravelMermaidErdServiceProvider.php
@@ -30,7 +30,7 @@ class LaravelMermaidErdServiceProvider extends PackageServiceProvider
         ));
 
         $this->app->bind(ModelScanner::class, fn (): ModelScanner => new ModelScanner(
-            config('mermaid-erd.models.paths') ?? [app_path('Models')],
+            config('mermaid-erd.models.paths') ?? [app_path()],
         ));
 
         $this->app->bind(SchemaBuilder::class, fn ($app): SchemaBuilder => new SchemaBuilder(

--- a/src/MermaidErdRenderer.php
+++ b/src/MermaidErdRenderer.php
@@ -107,6 +107,15 @@ class MermaidErdRenderer
 
         return match ($relation->type) {
             RelationType::ForeignKey => $this->renderForeignKeyRelation($relation, $schema, $parentSide),
+            RelationType::Eloquent => sprintf(
+                "    %s %s--%s %s : \"%s via %s\"\n",
+                $relation->from,
+                $parentSide,
+                $relation->oneToOne ? '||' : 'o{',
+                $relation->to,
+                $relation->declaredAs,
+                $relation->columns[0],
+            ),
             RelationType::Guessed => "    {$relation->from} {$parentSide}--o{ {$relation->to} : \"guessed has many via {$relation->columns[0]}\"\n",
             RelationType::Morph => "    {$relation->from} ||--o{ {$relation->to} : \"morphMany via {$relation->morphName}\"\n",
         };

--- a/src/MermaidErdRenderer.php
+++ b/src/MermaidErdRenderer.php
@@ -40,7 +40,11 @@ class MermaidErdRenderer
     private function renderTable(Table $table): string
     {
         $columnCount = count($table->columns);
-        $diagram = "    {$table->name}[\"{$table->name} ({$columnCount})\"] {\n";
+        $header = "{$table->name} ({$columnCount})";
+        if ($table->model !== null) {
+            $header .= ' · '.class_basename($table->model);
+        }
+        $diagram = "    {$table->name}[\"{$header}\"] {\n";
 
         foreach ($table->columns as $column) {
             $diagram .= $this->renderColumn($column)."\n";
@@ -73,6 +77,16 @@ class MermaidErdRenderer
         }
         if ($column->polymorphic) {
             $comments[] = 'polymorphic';
+        }
+        if ($column->cast !== null) {
+            $cast = str_contains($column->cast, '\\') ? class_basename($column->cast) : $column->cast;
+            $comments[] = "cast: {$cast}";
+        }
+        if ($column->accessor) {
+            $comments[] = 'accessor';
+        }
+        if ($column->mutator) {
+            $comments[] = 'mutator';
         }
         if ($column->nullable) {
             $comments[] = 'nullable';

--- a/src/Schema/Column.php
+++ b/src/Schema/Column.php
@@ -14,5 +14,8 @@ readonly class Column
         public bool $unique = false,
         public bool $softDelete = false,
         public bool $polymorphic = false,
+        public ?string $cast = null,
+        public bool $accessor = false,
+        public bool $mutator = false,
     ) {}
 }

--- a/src/Schema/ModelMetadata.php
+++ b/src/Schema/ModelMetadata.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+namespace Bambamboole\LaravelMermaidErd\Schema;
+
+readonly class ModelMetadata
+{
+    /**
+     * @param  class-string  $class
+     * @param  array<string, string>  $casts  attribute => cast (implicit key cast removed)
+     * @param  string[]  $accessors  snake-cased attribute names
+     * @param  string[]  $mutators  snake-cased attribute names
+     */
+    public function __construct(
+        public string $class,
+        public array $casts = [],
+        public array $accessors = [],
+        public array $mutators = [],
+    ) {}
+}

--- a/src/Schema/ModelScan.php
+++ b/src/Schema/ModelScan.php
@@ -7,9 +7,11 @@ readonly class ModelScan
     /**
      * @param  array<string, ModelMetadata>  $models  keyed by table name
      * @param  array<string, string[]>  $morphRelationships  "childTable.morphName" => target tables
+     * @param  ScannedRelation[]  $relations  non-morph relations declared on models
      */
     public function __construct(
         public array $models = [],
         public array $morphRelationships = [],
+        public array $relations = [],
     ) {}
 }

--- a/src/Schema/ModelScan.php
+++ b/src/Schema/ModelScan.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+namespace Bambamboole\LaravelMermaidErd\Schema;
+
+readonly class ModelScan
+{
+    /**
+     * @param  array<string, ModelMetadata>  $models  keyed by table name
+     * @param  array<string, string[]>  $morphRelationships  "childTable.morphName" => target tables
+     */
+    public function __construct(
+        public array $models = [],
+        public array $morphRelationships = [],
+    ) {}
+}

--- a/src/Schema/ModelScanner.php
+++ b/src/Schema/ModelScanner.php
@@ -4,8 +4,12 @@ namespace Bambamboole\LaravelMermaidErd\Schema;
 
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Str;
 use Spatie\StructureDiscoverer\Discover;
@@ -26,27 +30,30 @@ class ModelScanner
     {
         $models = [];
         $morphs = [];
+        $relations = [];
 
         foreach ($this->discoverModelClasses() as $class) {
             try {
-                $this->inspect($class, $models, $morphs);
+                $this->inspect($class, $models, $morphs, $relations);
             } catch (\Throwable) {
                 // A broken model must never kill diagram generation.
             }
         }
 
-        return new ModelScan($models, array_map(
-            fn (array $targets): array => array_values(array_unique($targets)),
-            $morphs,
-        ));
+        return new ModelScan(
+            $models,
+            array_map(fn (array $targets): array => array_values(array_unique($targets)), $morphs),
+            array_values($relations),
+        );
     }
 
     /**
      * @param  class-string  $class
      * @param  array<string, ModelMetadata>  $models
      * @param  array<string, string[]>  $morphs
+     * @param  array<string, ScannedRelation>  $relations
      */
-    private function inspect(string $class, array &$models, array &$morphs): void
+    private function inspect(string $class, array &$models, array &$morphs, array &$relations): void
     {
         $reflection = new \ReflectionClass($class);
         if (!$reflection->isSubclassOf(Model::class) || !$reflection->isInstantiable()) {
@@ -127,6 +134,46 @@ class ModelScanner
                 }
 
                 $morphs["{$childTable}.{$morphName}"][] = $target;
+
+                continue;
+            }
+
+            // MorphTo extends BelongsTo but has no static target — excluded.
+            if (is_a($typeName, MorphTo::class, true)) {
+                continue;
+            }
+
+            if (is_a($typeName, HasMany::class, true)
+                || is_a($typeName, HasOne::class, true)
+                || is_a($typeName, BelongsTo::class, true)) {
+                try {
+                    $relation = $method->invoke($model);
+                } catch (\Throwable) {
+                    continue;
+                }
+
+                if ($relation instanceof BelongsTo) {
+                    $from = $relation->getRelated()->getTable();
+                    $to = $table;
+                    $declaredAs = 'belongsTo';
+                } else {
+                    $from = $table;
+                    $to = $relation->getRelated()->getTable();
+                    $declaredAs = $relation instanceof HasOne ? 'hasOne' : 'hasMany';
+                }
+
+                $key = "{$from}|{$to}|{$relation->getForeignKeyName()}";
+                $existing = $relations[$key] ?? null;
+
+                // Both sides may declare the same relation; the has-side label wins.
+                if ($existing === null || ($existing->declaredAs === 'belongsTo' && $declaredAs !== 'belongsTo')) {
+                    $relations[$key] = new ScannedRelation(
+                        from: $from,
+                        to: $to,
+                        column: $relation->getForeignKeyName(),
+                        declaredAs: $declaredAs,
+                    );
+                }
             }
         }
 

--- a/src/Schema/ModelScanner.php
+++ b/src/Schema/ModelScanner.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Str;
+use Spatie\StructureDiscoverer\Discover;
 
 /**
  * Discovers Eloquent models and extracts diagram-relevant metadata. Only
@@ -158,51 +159,20 @@ class ModelScanner
      */
     private function discoverModelClasses(): array
     {
+        $paths = array_values(array_filter($this->paths, is_dir(...)));
+
+        if ($paths === []) {
+            return [];
+        }
+
         $classes = [];
-
-        foreach ($this->paths as $path) {
-            if (!is_dir($path)) {
-                continue;
-            }
-
-            $files = [];
-            $iterator = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
-            );
-            foreach ($iterator as $file) {
-                if ($file instanceof \SplFileInfo && $file->getExtension() === 'php') {
-                    $files[] = $file->getPathname();
-                }
-            }
-            sort($files);
-
-            foreach ($files as $file) {
-                $class = $this->classFromFile($file);
-                if ($class !== null) {
-                    $classes[] = $class;
-                }
+        foreach (Discover::in(...$paths)->classes()->get() as $class) {
+            if (is_string($class) && class_exists($class)) {
+                $classes[] = $class;
             }
         }
+        sort($classes);
 
         return $classes;
-    }
-
-    /**
-     * @return class-string|null
-     */
-    private function classFromFile(string $file): ?string
-    {
-        $contents = (string) file_get_contents($file);
-
-        if (!preg_match('/^namespace\s+([^;\s]+)\s*;/m', $contents, $namespace)) {
-            return null;
-        }
-        if (!preg_match('/^\s*(?:final\s+|abstract\s+|readonly\s+)*class\s+(\w+)/m', $contents, $class)) {
-            return null;
-        }
-
-        $fqcn = $namespace[1].'\\'.$class[1];
-
-        return class_exists($fqcn) ? $fqcn : null;
     }
 }

--- a/src/Schema/ModelScanner.php
+++ b/src/Schema/ModelScanner.php
@@ -1,0 +1,208 @@
+<?php
+declare(strict_types=1);
+namespace Bambamboole\LaravelMermaidErd\Schema;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Support\Str;
+
+/**
+ * Discovers Eloquent models and extracts diagram-relevant metadata. Only
+ * methods with an explicit Morph* or Attribute return type are ever invoked;
+ * a model that fails to instantiate or a relation that throws is skipped.
+ */
+class ModelScanner
+{
+    /**
+     * @param  string[]  $paths
+     */
+    public function __construct(private readonly array $paths) {}
+
+    public function scan(): ModelScan
+    {
+        $models = [];
+        $morphs = [];
+
+        foreach ($this->discoverModelClasses() as $class) {
+            try {
+                $this->inspect($class, $models, $morphs);
+            } catch (\Throwable) {
+                // A broken model must never kill diagram generation.
+            }
+        }
+
+        return new ModelScan($models, array_map(
+            fn (array $targets): array => array_values(array_unique($targets)),
+            $morphs,
+        ));
+    }
+
+    /**
+     * @param  class-string  $class
+     * @param  array<string, ModelMetadata>  $models
+     * @param  array<string, string[]>  $morphs
+     */
+    private function inspect(string $class, array &$models, array &$morphs): void
+    {
+        $reflection = new \ReflectionClass($class);
+        if (!$reflection->isSubclassOf(Model::class) || !$reflection->isInstantiable()) {
+            return;
+        }
+
+        /** @var Model $model */
+        $model = new $class;
+        $table = $model->getTable();
+
+        $accessors = [];
+        $mutators = [];
+
+        foreach ($reflection->getMethods() as $method) {
+            if ($method->isStatic() || str_starts_with($method->getDeclaringClass()->getName(), 'Illuminate\\')) {
+                continue;
+            }
+
+            $name = $method->getName();
+
+            // Legacy accessors/mutators receive the raw value as parameter.
+            if (preg_match('/^get(.+)Attribute$/', $name, $matches)) {
+                $accessors[] = Str::snake($matches[1]);
+
+                continue;
+            }
+            if (preg_match('/^set(.+)Attribute$/', $name, $matches)) {
+                $mutators[] = Str::snake($matches[1]);
+
+                continue;
+            }
+
+            if ($method->getNumberOfRequiredParameters() > 0) {
+                continue;
+            }
+
+            $returnType = $method->getReturnType();
+            if (!$returnType instanceof \ReflectionNamedType || $returnType->isBuiltin()) {
+                continue;
+            }
+            $typeName = $returnType->getName();
+
+            if (is_a($typeName, Attribute::class, true)) {
+                try {
+                    /** @var Attribute<mixed, mixed> $attribute */
+                    $attribute = $method->invoke($model);
+                } catch (\Throwable) {
+                    continue;
+                }
+                $attributeName = Str::snake($name);
+                if ($attribute->get !== null) {
+                    $accessors[] = $attributeName;
+                }
+                if ($attribute->set !== null) {
+                    $mutators[] = $attributeName;
+                }
+
+                continue;
+            }
+
+            if (is_a($typeName, MorphOne::class, true)
+                || is_a($typeName, MorphMany::class, true)
+                || is_a($typeName, MorphToMany::class, true)) {
+                try {
+                    $relation = $method->invoke($model);
+                } catch (\Throwable) {
+                    continue;
+                }
+
+                $morphName = Str::beforeLast($relation->getMorphType(), '_type');
+
+                if ($relation instanceof MorphToMany) {
+                    $childTable = $relation->getTable();
+                    $target = $relation->getInverse() ? $relation->getRelated()->getTable() : $table;
+                } else {
+                    $childTable = $relation->getRelated()->getTable();
+                    $target = $table;
+                }
+
+                $morphs["{$childTable}.{$morphName}"][] = $target;
+            }
+        }
+
+        // First discovered model wins when several share a table.
+        $models[$table] ??= new ModelMetadata(
+            class: $class,
+            casts: $this->declaredCasts($model),
+            accessors: array_values(array_unique($accessors)),
+            mutators: array_values(array_unique($mutators)),
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function declaredCasts(Model $model): array
+    {
+        $casts = $model->getCasts();
+
+        // getCasts() adds an implicit 'int' cast for incrementing keys — noise.
+        if ($model->getIncrementing() && ($casts[$model->getKeyName()] ?? null) === 'int') {
+            unset($casts[$model->getKeyName()]);
+        }
+
+        return $casts;
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    private function discoverModelClasses(): array
+    {
+        $classes = [];
+
+        foreach ($this->paths as $path) {
+            if (!is_dir($path)) {
+                continue;
+            }
+
+            $files = [];
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            );
+            foreach ($iterator as $file) {
+                if ($file instanceof \SplFileInfo && $file->getExtension() === 'php') {
+                    $files[] = $file->getPathname();
+                }
+            }
+            sort($files);
+
+            foreach ($files as $file) {
+                $class = $this->classFromFile($file);
+                if ($class !== null) {
+                    $classes[] = $class;
+                }
+            }
+        }
+
+        return $classes;
+    }
+
+    /**
+     * @return class-string|null
+     */
+    private function classFromFile(string $file): ?string
+    {
+        $contents = (string) file_get_contents($file);
+
+        if (!preg_match('/^namespace\s+([^;\s]+)\s*;/m', $contents, $namespace)) {
+            return null;
+        }
+        if (!preg_match('/^\s*(?:final\s+|abstract\s+|readonly\s+)*class\s+(\w+)/m', $contents, $class)) {
+            return null;
+        }
+
+        $fqcn = $namespace[1].'\\'.$class[1];
+
+        return class_exists($fqcn) ? $fqcn : null;
+    }
+}

--- a/src/Schema/Relation.php
+++ b/src/Schema/Relation.php
@@ -9,6 +9,7 @@ readonly class Relation
      * @param  string  $to  the table holding the reference (child)
      * @param  string[]  $columns  referencing column(s) on the child table
      * @param  ?string  $onDelete  lowercased action; null when absent or a no-op (no action, restrict)
+     * @param  ?string  $declaredAs  the Eloquent method that declared it, for Eloquent relations
      */
     public function __construct(
         public string $from,
@@ -19,6 +20,7 @@ readonly class Relation
         public bool $oneToOne = false,
         public ?string $onDelete = null,
         public ?string $morphName = null,
+        public ?string $declaredAs = null,
     ) {}
 
     public function selfReferential(): bool

--- a/src/Schema/RelationType.php
+++ b/src/Schema/RelationType.php
@@ -5,6 +5,7 @@ namespace Bambamboole\LaravelMermaidErd\Schema;
 enum RelationType
 {
     case ForeignKey;
+    case Eloquent;
     case Guessed;
     case Morph;
 }

--- a/src/Schema/ScannedRelation.php
+++ b/src/Schema/ScannedRelation.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+namespace Bambamboole\LaravelMermaidErd\Schema;
+
+readonly class ScannedRelation
+{
+    /**
+     * @param  string  $from  the referenced (parent) table
+     * @param  string  $to  the table holding the foreign key column (child)
+     * @param  string  $declaredAs  the Eloquent method that declared it (hasMany, hasOne, belongsTo)
+     */
+    public function __construct(
+        public string $from,
+        public string $to,
+        public string $column,
+        public string $declaredAs,
+    ) {}
+}

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -21,14 +21,18 @@ readonly class Schema
     /**
      * Lightweight graph representation for client-side filtering.
      *
-     * @return array{tables: array<string, string[]>, pivots: string[], edges: array<int, array{0: string, 1: string}>}
+     * @return array{tables: array<string, string[]>, models: array<string, string>, pivots: string[], edges: array<int, array{0: string, 1: string}>}
      */
     public function toGraph(): array
     {
         $tables = [];
+        $models = [];
         $pivots = [];
         foreach ($this->tables as $table) {
             $tables[$table->name] = array_map(fn (Column $column): string => $column->name, $table->columns);
+            if ($table->model !== null) {
+                $models[$table->name] = class_basename($table->model);
+            }
             if ($table->pivot) {
                 $pivots[] = $table->name;
             }
@@ -45,7 +49,7 @@ readonly class Schema
             $edges[] = [$relation->from, $relation->to];
         }
 
-        return ['tables' => $tables, 'pivots' => $pivots, 'edges' => $edges];
+        return ['tables' => $tables, 'models' => $models, 'pivots' => $pivots, 'edges' => $edges];
     }
 
     /**

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -21,6 +21,7 @@ class SchemaBuilder
         private readonly DatabaseInformationService $databaseInformationService,
         private readonly array $polymorphicRelationships = [],
         private readonly bool $guessRelationships = true,
+        private readonly ?ModelScan $models = null,
     ) {}
 
     public function build(): Schema
@@ -54,6 +55,11 @@ class SchemaBuilder
 
             [$morphNames, $polymorphicColumns] = $this->detectMorphs($columnNames);
 
+            $metadata = $this->models?->models[$tableName] ?? null;
+            $casts = $metadata->casts ?? [];
+            $accessors = $metadata->accessors ?? [];
+            $mutators = $metadata->mutators ?? [];
+
             $columns = [];
             $nullableColumns = [];
             foreach ($rawColumns as $rawColumn) {
@@ -72,6 +78,9 @@ class SchemaBuilder
                     unique: in_array($name, $uniqueColumns),
                     softDelete: $name === 'deleted_at',
                     polymorphic: in_array($name, $polymorphicColumns),
+                    cast: $casts[$name] ?? null,
+                    accessor: in_array($name, $accessors),
+                    mutator: in_array($name, $mutators),
                 );
             }
 
@@ -80,6 +89,7 @@ class SchemaBuilder
                 columns: $columns,
                 pivot: $this->isPivot($foreignKeys, $columnNames, $foreignKeyColumns),
                 morphNames: $morphNames,
+                model: $metadata?->class,
             );
 
             $meta[$tableName] = [
@@ -129,9 +139,13 @@ class SchemaBuilder
             }
         }
 
-        foreach ($this->polymorphicRelationships as $key => $targetTables) {
-            [$tableName, $morphName] = explode('.', (string) $key, 2);
+        foreach ($this->morphRelationships() as $key => $targetTables) {
+            [$tableName, $morphName] = explode('.', $key, 2);
             foreach ($targetTables as $targetTable) {
+                if (!isset($tables[$tableName]) || !isset($tables[$targetTable])) {
+                    continue;
+                }
+
                 $relations[] = new Relation(
                     from: $targetTable,
                     to: $tableName,
@@ -142,6 +156,22 @@ class SchemaBuilder
         }
 
         return $relations;
+    }
+
+    /**
+     * Scanned morph relations merged with the configured mappings.
+     *
+     * @return array<string, string[]>
+     */
+    private function morphRelationships(): array
+    {
+        $merged = $this->models->morphRelationships ?? [];
+
+        foreach ($this->polymorphicRelationships as $key => $targets) {
+            $merged[$key] = array_values(array_unique(array_merge($merged[$key] ?? [], $targets)));
+        }
+
+        return $merged;
     }
 
     /**

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Str;
 /**
  * @phpstan-import-type ForeignKeyRow from DatabaseInformationService
  *
- * @phpstan-type TableMeta array{foreignKeys: list<ForeignKeyRow>, uniqueColumns: string[], nullableColumns: string[], foreignKeyColumns: string[], polymorphicColumns: string[]}
+ * @phpstan-type TableMeta array{columnNames: string[], foreignKeys: list<ForeignKeyRow>, uniqueColumns: string[], nullableColumns: string[], foreignKeyColumns: string[], polymorphicColumns: string[]}
  */
 class SchemaBuilder
 {
@@ -93,6 +93,7 @@ class SchemaBuilder
             );
 
             $meta[$tableName] = [
+                'columnNames' => $columnNames,
                 'foreignKeys' => $foreignKeys,
                 'uniqueColumns' => $uniqueColumns,
                 'nullableColumns' => $nullableColumns,
@@ -114,6 +115,11 @@ class SchemaBuilder
     {
         $relations = [];
 
+        $scannedByChild = [];
+        foreach ($this->models->relations ?? [] as $scanned) {
+            $scannedByChild[$scanned->to][] = $scanned;
+        }
+
         foreach ($tableNames as $tableName) {
             foreach ($meta[$tableName]['foreignKeys'] as $foreignKey) {
                 $foreignTable = $foreignKey['foreign_table'];
@@ -134,8 +140,31 @@ class SchemaBuilder
                 );
             }
 
+            $modelCoveredColumns = [];
+            foreach ($scannedByChild[$tableName] ?? [] as $scanned) {
+                // A foreign key constraint is authoritative; the model relation
+                // only fills in where the schema has none.
+                if (!in_array($scanned->from, $tableNames)
+                    || !in_array($scanned->column, $meta[$tableName]['columnNames'])
+                    || in_array($scanned->column, $meta[$tableName]['foreignKeyColumns'])) {
+                    continue;
+                }
+
+                $modelCoveredColumns[] = $scanned->column;
+                $relations[] = new Relation(
+                    from: $scanned->from,
+                    to: $tableName,
+                    type: RelationType::Eloquent,
+                    columns: [$scanned->column],
+                    nullable: in_array($scanned->column, $meta[$tableName]['nullableColumns']),
+                    oneToOne: $scanned->declaredAs === 'hasOne'
+                        || in_array($scanned->column, $meta[$tableName]['uniqueColumns']),
+                    declaredAs: $scanned->declaredAs,
+                );
+            }
+
             if ($this->guessRelationships) {
-                array_push($relations, ...$this->guessRelations($tableName, $tableNames, $tables, $meta));
+                array_push($relations, ...$this->guessRelations($tableName, $tableNames, $tables, $meta, $modelCoveredColumns));
             }
         }
 
@@ -178,9 +207,10 @@ class SchemaBuilder
      * @param  string[]  $tableNames
      * @param  array<string, Table>  $tables
      * @param  array<string, TableMeta>  $meta
+     * @param  string[]  $modelCoveredColumns
      * @return list<Relation>
      */
-    private function guessRelations(string $tableName, array $tableNames, array $tables, array $meta): array
+    private function guessRelations(string $tableName, array $tableNames, array $tables, array $meta, array $modelCoveredColumns = []): array
     {
         $relations = [];
 
@@ -189,7 +219,8 @@ class SchemaBuilder
                 continue;
             }
 
-            if (in_array($column->name, $meta[$tableName]['foreignKeyColumns'])) {
+            if (in_array($column->name, $meta[$tableName]['foreignKeyColumns'])
+                || in_array($column->name, $modelCoveredColumns)) {
                 continue;
             }
 

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -7,11 +7,13 @@ readonly class Table
     /**
      * @param  Column[]  $columns
      * @param  string[]  $morphNames  detected morph pairs, e.g. ['reviewable']
+     * @param  class-string|null  $model  the Eloquent model backing this table, when discovered
      */
     public function __construct(
         public string $name,
         public array $columns,
         public bool $pivot = false,
         public array $morphNames = [],
+        public ?string $model = null,
     ) {}
 }

--- a/tests/ModelScannerTest.php
+++ b/tests/ModelScannerTest.php
@@ -57,6 +57,48 @@ it('discovers morph relations from typed relation methods', function (): void {
         ->and($morphs['attachments.attachable'])->toBe(['posts', 'videos']);
 });
 
+it('discovers non-morph relations and prefers the has-side declaration', function (): void {
+    $relations = collect(scanWorkbenchModels()->relations);
+
+    $aiMessages = $relations->first(fn ($relation): bool => $relation->to === 'ai_messages');
+
+    // Declared as belongsTo on AiMessage AND hasMany on User — has-side wins.
+    expect($aiMessages)->not->toBeNull()
+        ->and($aiMessages->from)->toBe('users')
+        ->and($aiMessages->column)->toBe('user_id')
+        ->and($aiMessages->declaredAs)->toBe('hasMany');
+});
+
+it('builds eloquent relations only where no foreign key exists', function (): void {
+    $schema = buildEnrichedSchema();
+
+    $aiMessages = collect($schema->relations)->first(fn ($relation): bool => $relation->to === 'ai_messages');
+
+    // ai_messages.user_id has no FK constraint: the model relation replaces the guess.
+    expect($aiMessages->type)->toBe(RelationType::Eloquent)
+        ->and($aiMessages->declaredAs)->toBe('hasMany')
+        ->and(collect($schema->relations)->contains(
+            fn ($relation): bool => $relation->to === 'ai_messages' && $relation->type === RelationType::Guessed,
+        ))->toBeFalse();
+
+    // posts.user_id has an FK constraint: Post::user() must not add a second edge.
+    $postUserEdges = collect($schema->relations)->filter(
+        fn ($relation): bool => $relation->to === 'posts' && $relation->columns === ['user_id'],
+    );
+    expect($postUserEdges)->toHaveCount(1)
+        ->and($postUserEdges->first()->type)->toBe(RelationType::ForeignKey);
+});
+
+it('renders eloquent relations with their declaring method', function (): void {
+    $diagram = (new MermaidErdRenderer)->render(buildEnrichedSchema());
+
+    expect($diagram)
+        ->toContain('users ||--o{ ai_messages : "hasMany via user_id"')
+        ->not->toContain('ai_messages : "guessed')
+        // audit_logs has no model — the heuristic guess remains.
+        ->toContain('audit_logs : "guessed has many via user_id"');
+});
+
 it('returns an empty scan for nonexistent paths', function (): void {
     $scan = (new ModelScanner(['/nonexistent/path']))->scan();
 

--- a/tests/ModelScannerTest.php
+++ b/tests/ModelScannerTest.php
@@ -1,0 +1,117 @@
+<?php declare(strict_types=1);
+
+use Bambamboole\LaravelMermaidErd\DatabaseInformationService;
+use Bambamboole\LaravelMermaidErd\MermaidErdRenderer;
+use Bambamboole\LaravelMermaidErd\Schema\ModelScan;
+use Bambamboole\LaravelMermaidErd\Schema\ModelScanner;
+use Bambamboole\LaravelMermaidErd\Schema\RelationType;
+use Bambamboole\LaravelMermaidErd\Schema\Schema;
+use Bambamboole\LaravelMermaidErd\Schema\SchemaBuilder;
+use Workbench\App\Enums\OrderStatus;
+use Workbench\App\Models\Order;
+use Workbench\App\Models\User;
+
+function scanWorkbenchModels(): ModelScan
+{
+    return (new ModelScanner([__DIR__.'/../workbench/app/Models']))->scan();
+}
+
+function buildEnrichedSchema(array $polymorphicRelationships = [], ?ModelScan $scan = null): Schema
+{
+    return (new SchemaBuilder(
+        new DatabaseInformationService(app('db')->connection()),
+        $polymorphicRelationships,
+        true,
+        $scan ?? scanWorkbenchModels(),
+    ))->build();
+}
+
+it('discovers models and keys them by table', function (): void {
+    $scan = scanWorkbenchModels();
+
+    expect($scan->models['orders']->class)->toBe(Order::class)
+        ->and($scan->models['users']->class)->toBe(User::class)
+        ->and($scan->models)->not->toHaveKey('post_tag');
+});
+
+it('collects declared casts without the implicit key cast', function (): void {
+    $casts = scanWorkbenchModels()->models['orders']->casts;
+
+    expect($casts['status'])->toBe(OrderStatus::class)
+        ->and($casts['placed_at'])->toBe('immutable_datetime')
+        ->and($casts)->not->toHaveKey('id');
+});
+
+it('detects modern and legacy accessors', function (): void {
+    $scan = scanWorkbenchModels();
+
+    expect($scan->models['customers']->accessors)->toContain('name')
+        ->and($scan->models['customers']->mutators)->not->toContain('name')
+        ->and($scan->models['videos']->accessors)->toContain('display_title');
+});
+
+it('discovers morph relations from typed relation methods', function (): void {
+    $morphs = scanWorkbenchModels()->morphRelationships;
+
+    expect($morphs['reviews.reviewable'])->toBe(['posts', 'videos'])
+        ->and($morphs['attachments.attachable'])->toBe(['posts', 'videos']);
+});
+
+it('returns an empty scan for nonexistent paths', function (): void {
+    $scan = (new ModelScanner(['/nonexistent/path']))->scan();
+
+    expect($scan->models)->toBe([])
+        ->and($scan->morphRelationships)->toBe([]);
+});
+
+it('annotates tables and columns with model metadata', function (): void {
+    $schema = buildEnrichedSchema();
+
+    $orders = $schema->table('orders');
+    expect($orders->model)->toBe(Order::class);
+
+    $status = collect($orders->columns)->firstWhere('name', 'status');
+    expect($status->cast)->toBe(OrderStatus::class);
+
+    $name = collect($schema->table('customers')->columns)->firstWhere('name', 'name');
+    expect($name->accessor)->toBeTrue()
+        ->and($name->mutator)->toBeFalse();
+});
+
+it('maps scanned morphs so nothing is left unmapped', function (): void {
+    expect(buildEnrichedSchema()->unmappedMorphs())->toBe([]);
+});
+
+it('merges configured morph targets with scanned ones', function (): void {
+    $schema = buildEnrichedSchema(['reviews.reviewable' => ['tags']]);
+
+    $targets = collect($schema->relations)
+        ->filter(fn ($relation): bool => $relation->type === RelationType::Morph && $relation->to === 'reviews')
+        ->pluck('from');
+
+    expect($targets->all())->toBe(['posts', 'videos', 'tags']);
+});
+
+it('skips morph relations pointing outside the schema', function (): void {
+    $schema = buildEnrichedSchema(['reviews.reviewable' => ['nonexistent_table']]);
+
+    expect(collect($schema->relations)->contains(fn ($relation): bool => $relation->from === 'nonexistent_table'))->toBeFalse();
+});
+
+it('renders model metadata into the diagram', function (): void {
+    $diagram = (new MermaidErdRenderer)->render(buildEnrichedSchema());
+
+    expect($diagram)
+        ->toContain('orders["orders (9) · Order"]')
+        ->toContain('cast: OrderStatus')
+        ->toContain('posts ||--o{ reviews : "morphMany via reviewable"')
+        ->toContain('videos ||--o{ attachments : "morphMany via attachable"')
+        ->toMatch('/customers\[.*?\] \{[^}]*\w+ name "accessor"/s');
+});
+
+it('includes model names in the graph payload', function (): void {
+    $graph = buildEnrichedSchema()->toGraph();
+
+    expect($graph['models']['orders'])->toBe('Order')
+        ->and($graph['models'])->not->toHaveKey('post_tag');
+});

--- a/workbench/app/Enums/OrderStatus.php
+++ b/workbench/app/Enums/OrderStatus.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+namespace Workbench\App\Enums;
+
+enum OrderStatus: string
+{
+    case Pending = 'pending';
+    case Paid = 'paid';
+    case Shipped = 'shipped';
+    case Cancelled = 'cancelled';
+}

--- a/workbench/app/Models/AiMessage.php
+++ b/workbench/app/Models/AiMessage.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+namespace Workbench\App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AiMessage extends Model
+{
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/workbench/app/Models/Attachment.php
+++ b/workbench/app/Models/Attachment.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+namespace Workbench\App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class Attachment extends Model
+{
+    public function attachable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/workbench/app/Models/Customer.php
+++ b/workbench/app/Models/Customer.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+namespace Workbench\App\Models;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+
+class Customer extends Model
+{
+    protected function name(): Attribute
+    {
+        return Attribute::make(
+            get: fn (string $value): string => ucfirst($value),
+        );
+    }
+}

--- a/workbench/app/Models/Order.php
+++ b/workbench/app/Models/Order.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+namespace Workbench\App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Workbench\App\Enums\OrderStatus;
+
+class Order extends Model
+{
+    use SoftDeletes;
+
+    #[\Override]
+    protected function casts(): array
+    {
+        return [
+            'status' => OrderStatus::class,
+            'placed_at' => 'immutable_datetime',
+        ];
+    }
+}

--- a/workbench/app/Models/Post.php
+++ b/workbench/app/Models/Post.php
@@ -2,10 +2,16 @@
 namespace Workbench\App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 class Post extends Model
 {
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
     public function reviews(): MorphMany
     {
         return $this->morphMany(Review::class, 'reviewable');

--- a/workbench/app/Models/Post.php
+++ b/workbench/app/Models/Post.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+namespace Workbench\App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+
+class Post extends Model
+{
+    public function reviews(): MorphMany
+    {
+        return $this->morphMany(Review::class, 'reviewable');
+    }
+
+    public function attachments(): MorphMany
+    {
+        return $this->morphMany(Attachment::class, 'attachable');
+    }
+}

--- a/workbench/app/Models/Review.php
+++ b/workbench/app/Models/Review.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+namespace Workbench\App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class Review extends Model
+{
+    public function reviewable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/workbench/app/Models/User.php
+++ b/workbench/app/Models/User.php
@@ -2,5 +2,12 @@
 namespace Workbench\App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
-class User extends Model {}
+class User extends Model
+{
+    public function aiMessages(): HasMany
+    {
+        return $this->hasMany(AiMessage::class);
+    }
+}

--- a/workbench/app/Models/User.php
+++ b/workbench/app/Models/User.php
@@ -1,0 +1,6 @@
+<?php declare(strict_types=1);
+namespace Workbench\App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model {}

--- a/workbench/app/Models/Video.php
+++ b/workbench/app/Models/Video.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+namespace Workbench\App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Video extends Model
+{
+    use SoftDeletes;
+
+    public function reviews(): MorphMany
+    {
+        return $this->morphMany(Review::class, 'reviewable');
+    }
+
+    public function attachments(): MorphMany
+    {
+        return $this->morphMany(Attachment::class, 'attachable');
+    }
+
+    public function getDisplayTitleAttribute(): string
+    {
+        return strtoupper((string) $this->getAttribute('title'));
+    }
+}

--- a/workbench/app/Providers/WorkbenchServiceProvider.php
+++ b/workbench/app/Providers/WorkbenchServiceProvider.php
@@ -32,6 +32,8 @@ class WorkbenchServiceProvider extends ServiceProvider
     {
         Route::view('/', 'welcome');
 
+        config(['mermaid-erd.models.paths' => [package_path('workbench/app/Models')]]);
+
         $this->redirectBoostSkillsToPackageRoot();
     }
 


### PR DESCRIPTION
The schema tells you what the database enforces; the models tell you what the app means. This PR adds a `ModelScanner` that merges the two:

**What it extracts**
- Owning model class per table → entity headers become `orders (9) · Order`
- Casts (minus Laravel's implicit incrementing-key cast), accessors and mutators per column → `varchar status "cast: OrderStatus, default: pending"`, `varchar name "accessor"`
- Polymorphic relations from methods return-typed `MorphOne`/`MorphMany`/`MorphToMany` (incl. inverse `MorphToMany`) → auto-fills what previously required manual `polymorphic_relationships` config. The config key still works and merges on top for morphs the scan can't see.

**Safety model** (as designed): typed-only invocation — a method is only ever called if its return type is a Morph relation or `Attribute`; legacy `get*/set*Attribute` accessors are detected by name without invocation. Every model and every call is failure-isolated, so a broken model degrades to "no metadata", never to a broken diagram.

**Scope decisions**: morphs only (non-morph model relations don't touch the guessed edges), columns only (accessor-only virtual attributes are not rendered).

**Plumbing**
- `models.enabled` / `models.paths` config (default `app_path('Models')` — empty in the Testbench skeleton, so schema-only behavior is byte-identical by default)
- `Schema::toGraph()` gains a `models` map; the web-view filter now matches model names (searching `Order` finds `orders`)
- Builder now also skips morph relations pointing at tables outside the schema (previously a config entry for an excluded table produced a dangling mermaid entity)
- Workbench demo models (morphs on Post/Video, `OrderStatus` enum cast, modern + legacy accessors); the README example ERD now shows model headers and auto-discovered morph edges

70 tests green (11 new), full `composer check` gate passes.