### PR TITLE
refactor: strip over-engineering found by audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ composer require bambamboole/laravel-mermaid-erd
 Optionally publish the config file to customize which tables are ignored:
 
 ```bash
-php artisan vendor:publish --tag="laravel-mermaid-erd-config"
+php artisan vendor:publish --tag="mermaid-erd-config"
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "php": "^8.3",
         "illuminate/contracts": "^12.0||^13.0",
         "laravel/prompts": "^0.3",
-        "spatie/laravel-package-tools": "^1.16",
         "spatie/php-structure-discoverer": "^2.4"
     },
     "require-dev": {

--- a/src/Commands/LaravelMermaidErdCommand.php
+++ b/src/Commands/LaravelMermaidErdCommand.php
@@ -5,10 +5,8 @@ namespace Bambamboole\LaravelMermaidErd\Commands;
 use Bambamboole\LaravelMermaidErd\DatabaseInformationService;
 use Bambamboole\LaravelMermaidErd\FileWriter;
 use Bambamboole\LaravelMermaidErd\MermaidErdRenderer;
-use Bambamboole\LaravelMermaidErd\Schema\ModelScanner;
 use Bambamboole\LaravelMermaidErd\Schema\SchemaBuilder;
 use Illuminate\Console\Command;
-use Illuminate\Filesystem\Filesystem;
 
 use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
@@ -44,13 +42,7 @@ class LaravelMermaidErdCommand extends Command
             config('mermaid-erd.schema'),
         );
 
-        $builder = new SchemaBuilder(
-            $service,
-            config('mermaid-erd.polymorphic_relationships', []),
-            config('mermaid-erd.guess_relationships', true),
-            config('mermaid-erd.models.enabled', true) ? $this->laravel->make(ModelScanner::class)->scan() : null,
-        );
-        $diagram = (new MermaidErdRenderer)->render($builder->build());
+        $diagram = (new MermaidErdRenderer)->render(SchemaBuilder::fromConfig($service)->build());
 
         $output = $this->stringOption('output') ?? select(
             label: 'How would you like to output the diagram?',
@@ -59,7 +51,6 @@ class LaravelMermaidErdCommand extends Command
         );
 
         return match ($output) {
-            'stdout' => $this->outputToStdout($diagram),
             'file' => $this->outputToFile($diagram),
             default => $this->outputToStdout($diagram),
         };
@@ -84,8 +75,7 @@ class LaravelMermaidErdCommand extends Command
             $path = base_path($path);
         }
 
-        $writer = new FileWriter(new Filesystem);
-        $writer->write($path, $diagram);
+        (new FileWriter)->write($path, $diagram);
 
         $this->info("Diagram written to {$path}");
 

--- a/src/FileWriter.php
+++ b/src/FileWriter.php
@@ -2,35 +2,29 @@
 declare(strict_types=1);
 namespace Bambamboole\LaravelMermaidErd;
 
-use Illuminate\Filesystem\Filesystem;
-
 class FileWriter
 {
     private const string START_TAG = '<!-- mermaid-erd-start -->';
 
     private const string END_TAG = '<!-- mermaid-erd-end -->';
 
-    public function __construct(
-        private readonly Filesystem $filesystem,
-    ) {}
-
     public function write(string $path, string $diagram): void
     {
         if (str_ends_with($path, '.mmd')) {
-            $this->filesystem->put($path, $diagram);
+            file_put_contents($path, $diagram);
 
             return;
         }
 
         $mermaidBlock = self::START_TAG."\n```mermaid\n{$diagram}```\n".self::END_TAG;
 
-        if (!$this->filesystem->exists($path)) {
-            $this->filesystem->put($path, "## ERD\n\n{$mermaidBlock}\n");
+        if (!file_exists($path)) {
+            file_put_contents($path, "## ERD\n\n{$mermaidBlock}\n");
 
             return;
         }
 
-        $content = $this->filesystem->get($path);
+        $content = (string) file_get_contents($path);
 
         if (str_contains($content, self::START_TAG) && str_contains($content, self::END_TAG)) {
             $pattern = '/'.preg_quote(self::START_TAG, '/').'.*?'.preg_quote(self::END_TAG, '/').'/s';
@@ -42,6 +36,6 @@ class FileWriter
             $content = rtrim($content)."\n\n## ERD\n\n{$mermaidBlock}\n";
         }
 
-        $this->filesystem->put($path, $content);
+        file_put_contents($path, $content);
     }
 }

--- a/src/Http/MermaidErdController.php
+++ b/src/Http/MermaidErdController.php
@@ -27,15 +27,9 @@ class MermaidErdController
             ];
         };
 
-        if (config('mermaid-erd.web.cache.enabled')) {
-            $data = Cache::remember(
-                $cacheKey,
-                config('mermaid-erd.web.cache.ttl', 3600),
-                $generate,
-            );
-        } else {
-            $data = $generate();
-        }
+        $data = config('mermaid-erd.web.cache.enabled')
+            ? Cache::remember($cacheKey, config('mermaid-erd.web.cache.ttl', 3600), $generate)
+            : $generate();
 
         if ($request->boolean('raw')) {
             return new Response($data['diagram'], 200, ['Content-Type' => 'text/plain; charset=UTF-8']);

--- a/src/LaravelMermaidErdServiceProvider.php
+++ b/src/LaravelMermaidErdServiceProvider.php
@@ -5,23 +5,15 @@ namespace Bambamboole\LaravelMermaidErd;
 use Bambamboole\LaravelMermaidErd\Commands\LaravelMermaidErdCommand;
 use Bambamboole\LaravelMermaidErd\Schema\ModelScanner;
 use Bambamboole\LaravelMermaidErd\Schema\SchemaBuilder;
-use Spatie\LaravelPackageTools\Package;
-use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Illuminate\Support\ServiceProvider;
 
-class LaravelMermaidErdServiceProvider extends PackageServiceProvider
+class LaravelMermaidErdServiceProvider extends ServiceProvider
 {
-    public function configurePackage(Package $package): void
+    #[\Override]
+    public function register(): void
     {
-        $package
-            ->name('laravel-mermaid-erd')
-            ->hasConfigFile()
-            ->hasViews()
-            ->hasRoute('web')
-            ->hasCommand(LaravelMermaidErdCommand::class);
-    }
+        $this->mergeConfigFrom(__DIR__.'/../config/mermaid-erd.php', 'mermaid-erd');
 
-    public function bootingPackage(): void
-    {
         $this->app->bind(DatabaseInformationService::class, fn ($app): DatabaseInformationService => new DatabaseInformationService(
             $app->make('db')->connection(),
             config('mermaid-erd.ignore_tables', []),
@@ -33,11 +25,24 @@ class LaravelMermaidErdServiceProvider extends PackageServiceProvider
             config('mermaid-erd.models.paths') ?? [app_path()],
         ));
 
-        $this->app->bind(SchemaBuilder::class, fn ($app): SchemaBuilder => new SchemaBuilder(
+        $this->app->bind(SchemaBuilder::class, fn ($app): SchemaBuilder => SchemaBuilder::fromConfig(
             $app->make(DatabaseInformationService::class),
-            config('mermaid-erd.polymorphic_relationships', []),
-            config('mermaid-erd.guess_relationships', true),
-            config('mermaid-erd.models.enabled', true) ? $app->make(ModelScanner::class)->scan() : null,
         ));
+    }
+
+    public function boot(): void
+    {
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'mermaid-erd');
+        $this->loadRoutesFrom(__DIR__.'/../routes/web.php');
+
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/mermaid-erd.php' => config_path('mermaid-erd.php'),
+            ], 'mermaid-erd-config');
+            $this->publishes([
+                __DIR__.'/../resources/views' => resource_path('views/vendor/mermaid-erd'),
+            ], 'mermaid-erd-views');
+            $this->commands(LaravelMermaidErdCommand::class);
+        }
     }
 }

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -29,7 +29,7 @@ readonly class Schema
         $models = [];
         $pivots = [];
         foreach ($this->tables as $table) {
-            $tables[$table->name] = array_map(fn (Column $column): string => $column->name, $table->columns);
+            $tables[$table->name] = array_keys($table->columns);
             if ($table->model !== null) {
                 $models[$table->name] = class_basename($table->model);
             }

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -7,8 +7,6 @@ use Illuminate\Support\Str;
 
 /**
  * @phpstan-import-type ForeignKeyRow from DatabaseInformationService
- *
- * @phpstan-type TableMeta array{columnNames: string[], foreignKeys: list<ForeignKeyRow>, uniqueColumns: string[], nullableColumns: string[], foreignKeyColumns: string[], polymorphicColumns: string[]}
  */
 class SchemaBuilder
 {
@@ -24,17 +22,27 @@ class SchemaBuilder
         private readonly ?ModelScan $models = null,
     ) {}
 
+    public static function fromConfig(DatabaseInformationService $databaseInformationService): self
+    {
+        return new self(
+            $databaseInformationService,
+            config('mermaid-erd.polymorphic_relationships', []),
+            config('mermaid-erd.guess_relationships', true),
+            config('mermaid-erd.models.enabled', true) ? app(ModelScanner::class)->scan() : null,
+        );
+    }
+
     public function build(): Schema
     {
         $tableNames = $this->databaseInformationService->getTables();
 
         $tables = [];
-        $meta = [];
+        $foreignKeysByTable = [];
 
         foreach ($tableNames as $tableName) {
             $rawColumns = $this->databaseInformationService->getColumns($tableName);
             $indexes = $this->databaseInformationService->getIndexes($tableName);
-            $foreignKeys = $this->databaseInformationService->getForeignKeys($tableName);
+            $foreignKeys = $foreignKeysByTable[$tableName] = $this->databaseInformationService->getForeignKeys($tableName);
 
             $columnNames = array_map(fn (array $column): string => $column['name'], $rawColumns);
 
@@ -61,14 +69,10 @@ class SchemaBuilder
             $mutators = $metadata->mutators ?? [];
 
             $columns = [];
-            $nullableColumns = [];
             foreach ($rawColumns as $rawColumn) {
                 $name = $rawColumn['name'];
-                if ($rawColumn['nullable']) {
-                    $nullableColumns[] = $name;
-                }
 
-                $columns[] = new Column(
+                $columns[$name] = new Column(
                     name: $name,
                     type: $rawColumn['type_name'],
                     nullable: (bool) $rawColumn['nullable'],
@@ -91,27 +95,18 @@ class SchemaBuilder
                 morphNames: $morphNames,
                 model: $metadata?->class,
             );
-
-            $meta[$tableName] = [
-                'columnNames' => $columnNames,
-                'foreignKeys' => $foreignKeys,
-                'uniqueColumns' => $uniqueColumns,
-                'nullableColumns' => $nullableColumns,
-                'foreignKeyColumns' => $foreignKeyColumns,
-                'polymorphicColumns' => $polymorphicColumns,
-            ];
         }
 
-        return new Schema($tables, $this->buildRelations($tableNames, $tables, $meta));
+        return new Schema($tables, $this->buildRelations($tableNames, $tables, $foreignKeysByTable));
     }
 
     /**
      * @param  string[]  $tableNames
      * @param  array<string, Table>  $tables
-     * @param  array<string, TableMeta>  $meta
+     * @param  array<string, list<ForeignKeyRow>>  $foreignKeysByTable
      * @return list<Relation>
      */
-    private function buildRelations(array $tableNames, array $tables, array $meta): array
+    private function buildRelations(array $tableNames, array $tables, array $foreignKeysByTable): array
     {
         $relations = [];
 
@@ -121,7 +116,9 @@ class SchemaBuilder
         }
 
         foreach ($tableNames as $tableName) {
-            foreach ($meta[$tableName]['foreignKeys'] as $foreignKey) {
+            $columns = $tables[$tableName]->columns;
+
+            foreach ($foreignKeysByTable[$tableName] as $foreignKey) {
                 $foreignTable = $foreignKey['foreign_table'];
 
                 if (!in_array($foreignTable, $tableNames)) {
@@ -133,20 +130,20 @@ class SchemaBuilder
                     to: $tableName,
                     type: RelationType::ForeignKey,
                     columns: $foreignKey['columns'],
-                    nullable: array_intersect($foreignKey['columns'], $meta[$tableName]['nullableColumns']) !== [],
+                    nullable: array_filter($foreignKey['columns'], fn (string $name): bool => $columns[$name]->nullable) !== [],
                     oneToOne: count($foreignKey['columns']) === 1
-                        && in_array($foreignKey['columns'][0], $meta[$tableName]['uniqueColumns']),
+                        && $columns[$foreignKey['columns'][0]]->unique,
                     onDelete: $this->normalizeOnDelete($foreignKey['on_delete'] ?? null),
                 );
             }
 
             $modelCoveredColumns = [];
             foreach ($scannedByChild[$tableName] ?? [] as $scanned) {
+                $column = $columns[$scanned->column] ?? null;
+
                 // A foreign key constraint is authoritative; the model relation
                 // only fills in where the schema has none.
-                if (!in_array($scanned->from, $tableNames)
-                    || !in_array($scanned->column, $meta[$tableName]['columnNames'])
-                    || in_array($scanned->column, $meta[$tableName]['foreignKeyColumns'])) {
+                if ($column === null || $column->foreignKey || !in_array($scanned->from, $tableNames)) {
                     continue;
                 }
 
@@ -156,15 +153,14 @@ class SchemaBuilder
                     to: $tableName,
                     type: RelationType::Eloquent,
                     columns: [$scanned->column],
-                    nullable: in_array($scanned->column, $meta[$tableName]['nullableColumns']),
-                    oneToOne: $scanned->declaredAs === 'hasOne'
-                        || in_array($scanned->column, $meta[$tableName]['uniqueColumns']),
+                    nullable: $column->nullable,
+                    oneToOne: $scanned->declaredAs === 'hasOne' || $column->unique,
                     declaredAs: $scanned->declaredAs,
                 );
             }
 
             if ($this->guessRelationships) {
-                array_push($relations, ...$this->guessRelations($tableName, $tableNames, $tables, $meta, $modelCoveredColumns));
+                array_push($relations, ...$this->guessRelations($tableName, $tableNames, $tables, $modelCoveredColumns));
             }
         }
 
@@ -206,11 +202,10 @@ class SchemaBuilder
     /**
      * @param  string[]  $tableNames
      * @param  array<string, Table>  $tables
-     * @param  array<string, TableMeta>  $meta
      * @param  string[]  $modelCoveredColumns
      * @return list<Relation>
      */
-    private function guessRelations(string $tableName, array $tableNames, array $tables, array $meta, array $modelCoveredColumns = []): array
+    private function guessRelations(string $tableName, array $tableNames, array $tables, array $modelCoveredColumns = []): array
     {
         $relations = [];
 
@@ -219,12 +214,7 @@ class SchemaBuilder
                 continue;
             }
 
-            if (in_array($column->name, $meta[$tableName]['foreignKeyColumns'])
-                || in_array($column->name, $modelCoveredColumns)) {
-                continue;
-            }
-
-            if (in_array($column->name, $meta[$tableName]['polymorphicColumns'])) {
+            if ($column->foreignKey || $column->polymorphic || in_array($column->name, $modelCoveredColumns)) {
                 continue;
             }
 

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -5,7 +5,7 @@ namespace Bambamboole\LaravelMermaidErd\Schema;
 readonly class Table
 {
     /**
-     * @param  Column[]  $columns
+     * @param  array<string, Column>  $columns  keyed by column name
      * @param  string[]  $morphNames  detected morph pairs, e.g. ['reviewable']
      * @param  class-string|null  $model  the Eloquent model backing this table, when discovered
      */


### PR DESCRIPTION
Removes a dependency and ~30 net lines with no behavior change; diagram output is byte-identical.

- Drop `spatie/laravel-package-tools` — a plain `ServiceProvider` covers config merge/publish, views, routes and command registration. View namespace and publish tags unchanged. Fixes the README publish tag, which was already wrong (`mermaid-erd-config`, not `laravel-mermaid-erd-config`).
- Key `Table::$columns` by name and read column facts (nullable/unique/FK/polymorphic) off the `Column` objects instead of a parallel `$meta` bookkeeping array in `SchemaBuilder`.
- Add `SchemaBuilder::fromConfig()` so the command and the container binding share one wiring recipe.
- `FileWriter` uses native file functions instead of an injected `Filesystem`; small shrinks in the controller (cache ternary) and command (redundant match arm).

`composer check` green: Pint, PHPStan, Rector, 73 tests / 295 assertions.