### PR TITLE
feat: annotate relations whose columns lack a supporting index

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,42 @@ Generated from this package's own test schema:
 <!-- mermaid-erd-start -->
 ```mermaid
 ---
-title: 9 tables · 52 columns
+title: 26 tables · 169 columns
 ---
 erDiagram
+    addresses["addresses (9)"] {
+        integer id PK
+        integer customer_id FK
+        varchar type "default: 'shipping'"
+        varchar street
+        varchar city
+        varchar zip
+        varchar country
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
     ai_messages["ai_messages (6) · AiMessage"] {
         integer id PK
         integer user_id
         text prompt
         text response "nullable"
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
+    attachments["attachments (7) · Attachment"] {
+        integer id PK
+        varchar attachable_type "polymorphic"
+        integer attachable_id "polymorphic"
+        varchar path
+        varchar mime_type "nullable"
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
+    audit_logs["audit_logs (6)"] {
+        integer id PK
+        integer user_id
+        varchar action
+        text payload "nullable"
         datetime created_at "nullable"
         datetime updated_at "nullable"
     }
@@ -40,6 +68,67 @@ erDiagram
         datetime created_at "nullable"
         datetime updated_at "nullable"
     }
+    coupon_order["coupon_order (5)"] {
+        integer id PK
+        integer coupon_id FK
+        integer order_id FK
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
+    coupons["coupons (6)"] {
+        integer id PK
+        varchar code UK
+        integer discount
+        datetime valid_until "nullable"
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
+    customers["customers (7) · Customer"] {
+        integer id PK
+        integer user_id FK "nullable"
+        varchar name "accessor"
+        varchar email UK
+        varchar phone "nullable"
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
+    invoices["invoices (6)"] {
+        integer id PK
+        integer order_id FK, UK
+        varchar number UK
+        datetime issued_at "nullable"
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
+    order_items["order_items (7)"] {
+        integer id PK
+        integer order_id FK
+        integer product_variant_id FK
+        integer quantity
+        integer unit_price
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
+    orders["orders (9) · Order"] {
+        integer id PK
+        integer customer_id FK
+        varchar number UK
+        varchar status "cast: OrderStatus, default: 'pending'"
+        integer total
+        datetime placed_at "cast: immutable_datetime, nullable"
+        datetime deleted_at "soft-delete, cast: datetime, nullable"
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
+    payments["payments (7)"] {
+        integer id PK
+        integer order_id FK
+        varchar method
+        integer amount
+        datetime paid_at "nullable"
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
     post_tag["post_tag (5)"] {
         integer id PK
         integer post_id FK
@@ -55,6 +144,27 @@ erDiagram
         datetime created_at "nullable"
         datetime updated_at "nullable"
     }
+    product_variants["product_variants (7)"] {
+        integer id PK
+        integer product_id FK
+        varchar sku UK
+        varchar options "nullable"
+        integer price "nullable"
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
+    products["products (10)"] {
+        integer id PK
+        integer supplier_id FK
+        integer category_id FK "nullable"
+        varchar name
+        varchar sku UK
+        integer price
+        text description "nullable"
+        datetime deleted_at "soft-delete, nullable"
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
     reviews["reviews (8) · Review"] {
         integer id PK
         varchar reviewable_type "polymorphic"
@@ -62,6 +172,39 @@ erDiagram
         integer user_id FK
         text body
         integer rating
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
+    shipment_items["shipment_items (6)"] {
+        integer id PK
+        integer shipment_id FK
+        integer order_item_id FK
+        integer quantity
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
+    shipments["shipments (7)"] {
+        integer id PK
+        integer order_id FK
+        integer warehouse_id FK
+        varchar tracking_number "nullable"
+        datetime shipped_at "nullable"
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
+    stocks["stocks (6)"] {
+        integer id PK
+        integer warehouse_id FK
+        integer product_variant_id FK
+        integer quantity "default: '0'"
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
+    suppliers["suppliers (6)"] {
+        integer id PK
+        varchar name
+        varchar email UK
+        varchar phone "nullable"
         datetime created_at "nullable"
         datetime updated_at "nullable"
     }
@@ -87,16 +230,45 @@ erDiagram
         datetime created_at "nullable"
         datetime updated_at "nullable"
     }
-    users ||--o{ ai_messages : "hasMany via user_id"
+    warehouses["warehouses (6)"] {
+        integer id PK
+        varchar name
+        varchar code UK
+        varchar address "nullable"
+        datetime created_at "nullable"
+        datetime updated_at "nullable"
+    }
+    customers ||--o{ addresses : "has many via customer_id, cascade delete"
+    users ||--o{ ai_messages : "hasMany via user_id, no index"
+    users ||--o{ audit_logs : "guessed has many via user_id, no index"
     categories |o--o{ categories : "self-ref via parent_id, set null delete"
     users ||--o{ comments : "has many via user_id, cascade delete"
     posts ||--o{ comments : "has many via post_id, cascade delete"
+    orders ||--o{ coupon_order : "pivot, has many via order_id, cascade delete"
+    coupons ||--o{ coupon_order : "pivot, has many via coupon_id, cascade delete"
+    users |o--o{ customers : "has many via user_id, set null delete"
+    orders ||--|| invoices : "has one via order_id, cascade delete"
+    product_variants ||--o{ order_items : "has many via product_variant_id"
+    orders ||--o{ order_items : "has many via order_id, cascade delete"
+    customers ||--o{ orders : "has many via customer_id, cascade delete"
+    orders ||--o{ payments : "has many via order_id, cascade delete"
     tags ||--o{ post_tag : "pivot, has many via tag_id, cascade delete"
     posts ||--o{ post_tag : "pivot, has many via post_id, cascade delete"
     users ||--o{ posts : "has many via user_id, cascade delete"
+    products ||--o{ product_variants : "has many via product_id, cascade delete"
+    categories |o--o{ products : "has many via category_id, set null delete"
+    suppliers ||--o{ products : "has many via supplier_id, cascade delete"
     users ||--o{ reviews : "has many via user_id, cascade delete"
+    order_items ||--o{ shipment_items : "has many via order_item_id, cascade delete"
+    shipments ||--o{ shipment_items : "has many via shipment_id, cascade delete"
+    warehouses ||--o{ shipments : "has many via warehouse_id"
+    orders ||--o{ shipments : "has many via order_id, cascade delete"
+    product_variants ||--o{ stocks : "has many via product_variant_id, cascade delete"
+    warehouses ||--o{ stocks : "has many via warehouse_id, cascade delete"
     posts ||--o{ reviews : "morphMany via reviewable"
     videos ||--o{ reviews : "morphMany via reviewable"
+    posts ||--o{ attachments : "morphMany via attachable"
+    videos ||--o{ attachments : "morphMany via attachable"
 ```
 <!-- mermaid-erd-end -->
 

--- a/src/MermaidErdRenderer.php
+++ b/src/MermaidErdRenderer.php
@@ -29,8 +29,9 @@ class MermaidErdRenderer
         if ($unmapped !== []) {
             $diagram .= "%% Unmapped polymorphic relations (add to config 'mermaid-erd.polymorphic_relationships'):\n";
             foreach ($unmapped as $pair) {
-                [, $morphName] = explode('.', $pair, 2);
-                $diagram .= "%%   {$pair} ({$morphName}_type + {$morphName}_id)\n";
+                [$tableName, $morphName] = explode('.', $pair, 2);
+                $noIndex = in_array($morphName, $schema->table($tableName)->unindexedMorphs ?? []) ? ', no index' : '';
+                $diagram .= "%%   {$pair} ({$morphName}_type + {$morphName}_id{$noIndex})\n";
             }
         }
 
@@ -104,21 +105,36 @@ class MermaidErdRenderer
     private function renderRelation(Relation $relation, Schema $schema): string
     {
         $parentSide = $relation->nullable ? '|o' : '||';
+        $noIndex = $relation->indexed ? '' : ', no index';
 
         return match ($relation->type) {
             RelationType::ForeignKey => $this->renderForeignKeyRelation($relation, $schema, $parentSide),
-            RelationType::Eloquent => sprintf(
-                "    %s %s--%s %s : \"%s via %s\"\n",
-                $relation->from,
-                $parentSide,
-                $relation->oneToOne ? '||' : 'o{',
-                $relation->to,
-                $relation->declaredAs,
-                $relation->columns[0],
-            ),
-            RelationType::Guessed => "    {$relation->from} {$parentSide}--o{ {$relation->to} : \"guessed has many via {$relation->columns[0]}\"\n",
-            RelationType::Morph => "    {$relation->from} ||--o{ {$relation->to} : \"morphMany via {$relation->morphName}\"\n",
+            RelationType::Eloquent => $this->renderEloquentRelation($relation, $schema, $parentSide),
+            RelationType::Guessed => "    {$relation->from} {$parentSide}--o{ {$relation->to} : \"guessed has many via {$relation->columns[0]}{$noIndex}\"\n",
+            RelationType::Morph => "    {$relation->from} ||--o{ {$relation->to} : \"morphMany via {$relation->morphName}{$noIndex}\"\n",
         };
+    }
+
+    private function renderEloquentRelation(Relation $relation, Schema $schema, string $parentSide): string
+    {
+        $label = "{$relation->declaredAs} via {$relation->columns[0]}";
+
+        $column = $schema->table($relation->to)?->columns[$relation->columns[0]] ?? null;
+        if (!$relation->indexed) {
+            $label .= ', no index';
+        } elseif ($relation->declaredAs === 'hasOne' && $column !== null && !$column->unique) {
+            // The code assumes one child row per parent; the database permits more.
+            $label .= ', no unique index';
+        }
+
+        return sprintf(
+            "    %s %s--%s %s : \"%s\"\n",
+            $relation->from,
+            $parentSide,
+            $relation->oneToOne ? '||' : 'o{',
+            $relation->to,
+            $label,
+        );
     }
 
     private function renderForeignKeyRelation(Relation $relation, Schema $schema, string $parentSide): string
@@ -134,6 +150,10 @@ class MermaidErdRenderer
 
         if ($relation->onDelete !== null) {
             $label .= ", {$relation->onDelete} delete";
+        }
+
+        if (!$relation->indexed) {
+            $label .= ', no index';
         }
 
         if ($schema->table($relation->to)?->pivot) {

--- a/src/Schema/Relation.php
+++ b/src/Schema/Relation.php
@@ -9,7 +9,9 @@ readonly class Relation
      * @param  string  $to  the table holding the reference (child)
      * @param  string[]  $columns  referencing column(s) on the child table
      * @param  ?string  $onDelete  lowercased action; null when absent or a no-op (no action, restrict)
+     * @param  ?string  $morphName  the morph name, for Morph relations
      * @param  ?string  $declaredAs  the Eloquent method that declared it, for Eloquent relations
+     * @param  bool  $indexed  whether the referencing columns have a supporting index on the child table
      */
     public function __construct(
         public string $from,
@@ -21,6 +23,7 @@ readonly class Relation
         public ?string $onDelete = null,
         public ?string $morphName = null,
         public ?string $declaredAs = null,
+        public bool $indexed = true,
     ) {}
 
     public function selfReferential(): bool

--- a/src/Schema/SchemaBuilder.php
+++ b/src/Schema/SchemaBuilder.php
@@ -38,11 +38,17 @@ class SchemaBuilder
 
         $tables = [];
         $foreignKeysByTable = [];
+        $indexesByTable = [];
 
         foreach ($tableNames as $tableName) {
             $rawColumns = $this->databaseInformationService->getColumns($tableName);
             $indexes = $this->databaseInformationService->getIndexes($tableName);
             $foreignKeys = $foreignKeysByTable[$tableName] = $this->databaseInformationService->getForeignKeys($tableName);
+
+            // Ordered column lists; expression indexes report no columns and are skipped.
+            $indexColumns = $indexesByTable[$tableName] = array_values(array_filter(
+                array_map(fn (array $index): array => $index['columns'], $indexes),
+            ));
 
             $columnNames = array_map(fn (array $column): string => $column['name'], $rawColumns);
 
@@ -93,20 +99,25 @@ class SchemaBuilder
                 columns: $columns,
                 pivot: $this->isPivot($foreignKeys, $columnNames, $foreignKeyColumns),
                 morphNames: $morphNames,
+                unindexedMorphs: array_values(array_filter(
+                    $morphNames,
+                    fn (string $morphName): bool => !$this->morphPairIndexed($indexColumns, $morphName),
+                )),
                 model: $metadata?->class,
             );
         }
 
-        return new Schema($tables, $this->buildRelations($tableNames, $tables, $foreignKeysByTable));
+        return new Schema($tables, $this->buildRelations($tableNames, $tables, $foreignKeysByTable, $indexesByTable));
     }
 
     /**
      * @param  string[]  $tableNames
      * @param  array<string, Table>  $tables
      * @param  array<string, list<ForeignKeyRow>>  $foreignKeysByTable
+     * @param  array<string, list<string[]>>  $indexesByTable
      * @return list<Relation>
      */
-    private function buildRelations(array $tableNames, array $tables, array $foreignKeysByTable): array
+    private function buildRelations(array $tableNames, array $tables, array $foreignKeysByTable, array $indexesByTable): array
     {
         $relations = [];
 
@@ -117,6 +128,7 @@ class SchemaBuilder
 
         foreach ($tableNames as $tableName) {
             $columns = $tables[$tableName]->columns;
+            $indexes = $indexesByTable[$tableName];
 
             foreach ($foreignKeysByTable[$tableName] as $foreignKey) {
                 $foreignTable = $foreignKey['foreign_table'];
@@ -134,6 +146,7 @@ class SchemaBuilder
                     oneToOne: count($foreignKey['columns']) === 1
                         && $columns[$foreignKey['columns'][0]]->unique,
                     onDelete: $this->normalizeOnDelete($foreignKey['on_delete'] ?? null),
+                    indexed: $this->hasSupportingIndex($indexes, $foreignKey['columns']),
                 );
             }
 
@@ -156,11 +169,12 @@ class SchemaBuilder
                     nullable: $column->nullable,
                     oneToOne: $scanned->declaredAs === 'hasOne' || $column->unique,
                     declaredAs: $scanned->declaredAs,
+                    indexed: $this->hasSupportingIndex($indexes, [$scanned->column]),
                 );
             }
 
             if ($this->guessRelationships) {
-                array_push($relations, ...$this->guessRelations($tableName, $tableNames, $tables, $modelCoveredColumns));
+                array_push($relations, ...$this->guessRelations($tableName, $tableNames, $tables, $indexes, $modelCoveredColumns));
             }
         }
 
@@ -176,6 +190,7 @@ class SchemaBuilder
                     to: $tableName,
                     type: RelationType::Morph,
                     morphName: $morphName,
+                    indexed: $this->morphPairIndexed($indexesByTable[$tableName], $morphName),
                 );
             }
         }
@@ -202,10 +217,11 @@ class SchemaBuilder
     /**
      * @param  string[]  $tableNames
      * @param  array<string, Table>  $tables
+     * @param  list<string[]>  $indexes
      * @param  string[]  $modelCoveredColumns
      * @return list<Relation>
      */
-    private function guessRelations(string $tableName, array $tableNames, array $tables, array $modelCoveredColumns = []): array
+    private function guessRelations(string $tableName, array $tableNames, array $tables, array $indexes, array $modelCoveredColumns = []): array
     {
         $relations = [];
 
@@ -230,10 +246,42 @@ class SchemaBuilder
                 type: RelationType::Guessed,
                 columns: [$column->name],
                 nullable: $column->nullable,
+                indexed: $this->hasSupportingIndex($indexes, [$column->name]),
             );
         }
 
         return $relations;
+    }
+
+    /**
+     * True when the leading columns of some index are exactly the given
+     * columns (any order among them) — the leftmost-prefix rule.
+     *
+     * @param  list<string[]>  $indexes  ordered column lists
+     * @param  string[]  $columns
+     */
+    private function hasSupportingIndex(array $indexes, array $columns): bool
+    {
+        foreach ($indexes as $indexColumns) {
+            if (count($indexColumns) >= count($columns)
+                && array_diff($columns, array_slice($indexColumns, 0, count($columns))) === []) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Eloquent queries morphs as `type = ? AND id = ?`: covered by an index
+     * leading with the id column or with the pair in either order.
+     *
+     * @param  list<string[]>  $indexes
+     */
+    private function morphPairIndexed(array $indexes, string $morphName): bool
+    {
+        return $this->hasSupportingIndex($indexes, ["{$morphName}_id"])
+            || $this->hasSupportingIndex($indexes, ["{$morphName}_type", "{$morphName}_id"]);
     }
 
     /**

--- a/src/Schema/Table.php
+++ b/src/Schema/Table.php
@@ -7,6 +7,7 @@ readonly class Table
     /**
      * @param  array<string, Column>  $columns  keyed by column name
      * @param  string[]  $morphNames  detected morph pairs, e.g. ['reviewable']
+     * @param  string[]  $unindexedMorphs  morph names whose column pair lacks a supporting index
      * @param  class-string|null  $model  the Eloquent model backing this table, when discovered
      */
     public function __construct(
@@ -14,6 +15,7 @@ readonly class Table
         public array $columns,
         public bool $pivot = false,
         public array $morphNames = [],
+        public array $unindexedMorphs = [],
         public ?string $model = null,
     ) {}
 }

--- a/tests/LaravelMermaidErdCommandTest.php
+++ b/tests/LaravelMermaidErdCommandTest.php
@@ -258,7 +258,7 @@ it('guesses relationships for _id columns without FK constraints', function (): 
     $output = Artisan::output();
 
     expect($output)
-        ->toContain('users ||--o{ ai_messages : "guessed has many via user_id"');
+        ->toContain('users ||--o{ ai_messages : "guessed has many via user_id, no index"');
 });
 
 it('does not guess relationships when config is disabled', function (): void {

--- a/tests/ModelScannerTest.php
+++ b/tests/ModelScannerTest.php
@@ -93,10 +93,10 @@ it('renders eloquent relations with their declaring method', function (): void {
     $diagram = (new MermaidErdRenderer)->render(buildEnrichedSchema());
 
     expect($diagram)
-        ->toContain('users ||--o{ ai_messages : "hasMany via user_id"')
+        ->toContain('users ||--o{ ai_messages : "hasMany via user_id, no index"')
         ->not->toContain('ai_messages : "guessed')
         // audit_logs has no model — the heuristic guess remains.
-        ->toContain('audit_logs : "guessed has many via user_id"');
+        ->toContain('audit_logs : "guessed has many via user_id, no index"');
 });
 
 it('returns an empty scan for nonexistent paths', function (): void {

--- a/tests/SchemaBuilderTest.php
+++ b/tests/SchemaBuilderTest.php
@@ -1,9 +1,14 @@
 <?php declare(strict_types=1);
 
 use Bambamboole\LaravelMermaidErd\DatabaseInformationService;
+use Bambamboole\LaravelMermaidErd\MermaidErdRenderer;
+use Bambamboole\LaravelMermaidErd\Schema\ModelScan;
 use Bambamboole\LaravelMermaidErd\Schema\RelationType;
+use Bambamboole\LaravelMermaidErd\Schema\ScannedRelation;
 use Bambamboole\LaravelMermaidErd\Schema\Schema;
 use Bambamboole\LaravelMermaidErd\Schema\SchemaBuilder;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema as SchemaFacade;
 
 function buildSchema(array $polymorphicRelationships = [], bool $guessRelationships = true): Schema
 {
@@ -107,6 +112,74 @@ it('builds morph relations from configured mappings', function (): void {
 
 it('reports unmapped morph pairs', function (): void {
     expect(buildSchema()->unmappedMorphs())->toBe(['attachments.attachable', 'reviews.reviewable']);
+});
+
+it('flags relation columns without a supporting index', function (): void {
+    $relations = collect(buildSchema()->relations);
+
+    $guessed = $relations->first(fn ($r): bool => $r->to === 'ai_messages');
+    $constrained = $relations->first(fn ($r): bool => $r->to === 'posts' && $r->columns === ['user_id']);
+
+    expect($guessed->indexed)->toBeFalse()
+        ->and($constrained->indexed)->toBeTrue();
+});
+
+it('accepts only indexes that lead with the relation column', function (): void {
+    SchemaFacade::create('metrics', function (Blueprint $table): void {
+        $table->id();
+        $table->unsignedBigInteger('user_id');
+        $table->unsignedBigInteger('customer_id');
+        $table->timestamp('recorded_at')->nullable();
+        $table->index(['user_id', 'recorded_at']);
+        $table->index(['recorded_at', 'customer_id']);
+    });
+
+    $relations = collect(buildSchema()->relations)
+        ->where('to', 'metrics')
+        ->keyBy(fn ($r): string => $r->columns[0]);
+
+    expect($relations['user_id']->indexed)->toBeTrue()
+        ->and($relations['customer_id']->indexed)->toBeFalse();
+
+    SchemaFacade::drop('metrics');
+});
+
+it('flags morph pairs without a supporting index', function (): void {
+    SchemaFacade::create('badges', function (Blueprint $table): void {
+        $table->id();
+        $table->string('badgeable_type');
+        $table->unsignedBigInteger('badgeable_id');
+    });
+
+    $mapped = buildSchema(polymorphicRelationships: ['badges.badgeable' => ['posts']]);
+    $morph = collect($mapped->relations)->first(fn ($r): bool => $r->to === 'badges');
+
+    expect($morph->indexed)->toBeFalse()
+        ->and($mapped->table('badges')->unindexedMorphs)->toBe(['badgeable'])
+        ->and($mapped->table('reviews')->unindexedMorphs)->toBe([])
+        ->and((new MermaidErdRenderer)->render($mapped))
+        ->toContain('posts ||--o{ badges : "morphMany via badgeable, no index"')
+        ->and((new MermaidErdRenderer)->render(buildSchema()))
+        ->toContain('%%   badges.badgeable (badgeable_type + badgeable_id, no index)');
+
+    SchemaFacade::drop('badges');
+});
+
+it('annotates hasOne relations without a unique index', function (): void {
+    SchemaFacade::create('profiles', function (Blueprint $table): void {
+        $table->id();
+        $table->unsignedBigInteger('user_id')->index();
+    });
+
+    $schema = (new SchemaBuilder(
+        new DatabaseInformationService(app('db')->connection()),
+        models: new ModelScan(relations: [new ScannedRelation('users', 'profiles', 'user_id', 'hasOne')]),
+    ))->build();
+
+    expect((new MermaidErdRenderer)->render($schema))
+        ->toContain('users ||--|| profiles : "hasOne via user_id, no unique index"');
+
+    SchemaFacade::drop('profiles');
 });
 
 it('exposes a graph representation for filtering', function (): void {

--- a/workbench/database/migrations/0001_01_01_000002_create_posts_table.php
+++ b/workbench/database/migrations/0001_01_01_000002_create_posts_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('user_id')->index()->constrained('users')->cascadeOnDelete();
             $table->string('title');
             $table->text('body');
             $table->timestamps();

--- a/workbench/database/migrations/0001_01_01_000003_create_comments_table.php
+++ b/workbench/database/migrations/0001_01_01_000003_create_comments_table.php
@@ -10,8 +10,8 @@ return new class extends Migration
     {
         Schema::create('comments', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('post_id')->constrained('posts')->cascadeOnDelete();
-            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('post_id')->index()->constrained('posts')->cascadeOnDelete();
+            $table->foreignId('user_id')->index()->constrained('users')->cascadeOnDelete();
             $table->text('body');
             $table->timestamps();
         });

--- a/workbench/database/migrations/0001_01_01_000005_create_post_tag_table.php
+++ b/workbench/database/migrations/0001_01_01_000005_create_post_tag_table.php
@@ -10,8 +10,8 @@ return new class extends Migration
     {
         Schema::create('post_tag', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('post_id')->constrained('posts')->cascadeOnDelete();
-            $table->foreignId('tag_id')->constrained('tags')->cascadeOnDelete();
+            $table->foreignId('post_id')->index()->constrained('posts')->cascadeOnDelete();
+            $table->foreignId('tag_id')->index()->constrained('tags')->cascadeOnDelete();
             $table->timestamps();
         });
     }

--- a/workbench/database/migrations/0001_01_01_000007_create_reviews_table.php
+++ b/workbench/database/migrations/0001_01_01_000007_create_reviews_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
         Schema::create('reviews', function (Blueprint $table) {
             $table->id();
             $table->morphs('reviewable');
-            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('user_id')->index()->constrained('users')->cascadeOnDelete();
             $table->text('body');
             $table->tinyInteger('rating');
             $table->timestamps();

--- a/workbench/database/migrations/0001_01_01_000008_create_categories_table.php
+++ b/workbench/database/migrations/0001_01_01_000008_create_categories_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
         Schema::create('categories', function (Blueprint $table) {
             $table->id();
             $table->string('name');
-            $table->foreignId('parent_id')->nullable()->constrained('categories')->nullOnDelete();
+            $table->foreignId('parent_id')->nullable()->index()->constrained('categories')->nullOnDelete();
             $table->timestamps();
         });
     }

--- a/workbench/database/migrations/0001_01_01_000010_create_customers_table.php
+++ b/workbench/database/migrations/0001_01_01_000010_create_customers_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
     {
         Schema::create('customers', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('user_id')->nullable()->index()->constrained('users')->nullOnDelete();
             $table->string('name');
             $table->string('email')->unique();
             $table->string('phone')->nullable();

--- a/workbench/database/migrations/0001_01_01_000011_create_addresses_table.php
+++ b/workbench/database/migrations/0001_01_01_000011_create_addresses_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
     {
         Schema::create('addresses', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('customer_id')->constrained('customers')->cascadeOnDelete();
+            $table->foreignId('customer_id')->index()->constrained('customers')->cascadeOnDelete();
             $table->string('type')->default('shipping');
             $table->string('street');
             $table->string('city');

--- a/workbench/database/migrations/0001_01_01_000014_create_products_table.php
+++ b/workbench/database/migrations/0001_01_01_000014_create_products_table.php
@@ -10,8 +10,8 @@ return new class extends Migration
     {
         Schema::create('products', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('supplier_id')->constrained('suppliers')->cascadeOnDelete();
-            $table->foreignId('category_id')->nullable()->constrained('categories')->nullOnDelete();
+            $table->foreignId('supplier_id')->index()->constrained('suppliers')->cascadeOnDelete();
+            $table->foreignId('category_id')->nullable()->index()->constrained('categories')->nullOnDelete();
             $table->string('name');
             $table->string('sku')->unique();
             $table->integer('price');

--- a/workbench/database/migrations/0001_01_01_000015_create_product_variants_table.php
+++ b/workbench/database/migrations/0001_01_01_000015_create_product_variants_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
     {
         Schema::create('product_variants', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('product_id')->constrained('products')->cascadeOnDelete();
+            $table->foreignId('product_id')->index()->constrained('products')->cascadeOnDelete();
             $table->string('sku')->unique();
             $table->string('options')->nullable();
             $table->integer('price')->nullable();

--- a/workbench/database/migrations/0001_01_01_000016_create_stocks_table.php
+++ b/workbench/database/migrations/0001_01_01_000016_create_stocks_table.php
@@ -10,8 +10,8 @@ return new class extends Migration
     {
         Schema::create('stocks', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('warehouse_id')->constrained('warehouses')->cascadeOnDelete();
-            $table->foreignId('product_variant_id')->constrained('product_variants')->cascadeOnDelete();
+            $table->foreignId('warehouse_id')->index()->constrained('warehouses')->cascadeOnDelete();
+            $table->foreignId('product_variant_id')->index()->constrained('product_variants')->cascadeOnDelete();
             $table->integer('quantity')->default('0');
             $table->timestamps();
         });

--- a/workbench/database/migrations/0001_01_01_000017_create_orders_table.php
+++ b/workbench/database/migrations/0001_01_01_000017_create_orders_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
     {
         Schema::create('orders', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('customer_id')->constrained('customers')->cascadeOnDelete();
+            $table->foreignId('customer_id')->index()->constrained('customers')->cascadeOnDelete();
             $table->string('number')->unique();
             $table->string('status')->default('pending');
             $table->integer('total');

--- a/workbench/database/migrations/0001_01_01_000018_create_order_items_table.php
+++ b/workbench/database/migrations/0001_01_01_000018_create_order_items_table.php
@@ -10,8 +10,8 @@ return new class extends Migration
     {
         Schema::create('order_items', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('order_id')->constrained('orders')->cascadeOnDelete();
-            $table->foreignId('product_variant_id')->constrained('product_variants')->restrictOnDelete();
+            $table->foreignId('order_id')->index()->constrained('orders')->cascadeOnDelete();
+            $table->foreignId('product_variant_id')->index()->constrained('product_variants')->restrictOnDelete();
             $table->integer('quantity');
             $table->integer('unit_price');
             $table->timestamps();

--- a/workbench/database/migrations/0001_01_01_000020_create_coupon_order_table.php
+++ b/workbench/database/migrations/0001_01_01_000020_create_coupon_order_table.php
@@ -10,8 +10,8 @@ return new class extends Migration
     {
         Schema::create('coupon_order', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('coupon_id')->constrained('coupons')->cascadeOnDelete();
-            $table->foreignId('order_id')->constrained('orders')->cascadeOnDelete();
+            $table->foreignId('coupon_id')->index()->constrained('coupons')->cascadeOnDelete();
+            $table->foreignId('order_id')->index()->constrained('orders')->cascadeOnDelete();
             $table->timestamps();
         });
     }

--- a/workbench/database/migrations/0001_01_01_000021_create_payments_table.php
+++ b/workbench/database/migrations/0001_01_01_000021_create_payments_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
     {
         Schema::create('payments', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('order_id')->constrained('orders')->cascadeOnDelete();
+            $table->foreignId('order_id')->index()->constrained('orders')->cascadeOnDelete();
             $table->string('method');
             $table->integer('amount');
             $table->timestamp('paid_at')->nullable();

--- a/workbench/database/migrations/0001_01_01_000023_create_shipments_table.php
+++ b/workbench/database/migrations/0001_01_01_000023_create_shipments_table.php
@@ -10,8 +10,8 @@ return new class extends Migration
     {
         Schema::create('shipments', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('order_id')->constrained('orders')->cascadeOnDelete();
-            $table->foreignId('warehouse_id')->constrained('warehouses')->restrictOnDelete();
+            $table->foreignId('order_id')->index()->constrained('orders')->cascadeOnDelete();
+            $table->foreignId('warehouse_id')->index()->constrained('warehouses')->restrictOnDelete();
             $table->string('tracking_number')->nullable();
             $table->timestamp('shipped_at')->nullable();
             $table->timestamps();

--- a/workbench/database/migrations/0001_01_01_000024_create_shipment_items_table.php
+++ b/workbench/database/migrations/0001_01_01_000024_create_shipment_items_table.php
@@ -10,8 +10,8 @@ return new class extends Migration
     {
         Schema::create('shipment_items', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('shipment_id')->constrained('shipments')->cascadeOnDelete();
-            $table->foreignId('order_item_id')->constrained('order_items')->cascadeOnDelete();
+            $table->foreignId('shipment_id')->index()->constrained('shipments')->cascadeOnDelete();
+            $table->foreignId('order_item_id')->index()->constrained('order_items')->cascadeOnDelete();
             $table->integer('quantity');
             $table->timestamps();
         });


### PR DESCRIPTION
The diagram now surfaces missing indexes derived from the relation map: each relation's referencing columns are compared against the child table's indexes using the leftmost-prefix rule (an index on `(user_id, created_at)` covers `user_id`; `(created_at, user_id)` does not).

- FK, Eloquent, guessed and morph relations render `no index` when unsupported; unmapped morph pairs get the suffix in the existing `%%` footer. Morph pairs count as covered when an index leads with the `_id` column or the type/id pair (so `morphs()` passes).
- `hasOne` relations whose column is indexed but not unique render `no unique index` — the code assumes one child row per parent, the database permits more.
- Workbench FK columns got explicit indexes so output is identical across drivers (InnoDB auto-indexes FK columns, SQLite/Postgres don't). `ai_messages.user_id` and `audit_logs.user_id` stay unindexed deliberately as demos.
- The regenerated README ERD was stale (9 of 26 tables) and now shows the full workbench schema.

Before:
```
users ||--o{ ai_messages : "hasMany via user_id"
users ||--o{ audit_logs : "guessed has many via user_id"
```

After:
```
users ||--o{ ai_messages : "hasMany via user_id, no index"
users ||--o{ audit_logs : "guessed has many via user_id, no index"
users ||--|| profiles : "hasOne via user_id, no unique index"
%%   badges.badgeable (badgeable_type + badgeable_id, no index)
```